### PR TITLE
Support for non-default request handlers

### DIFF
--- a/src/main/java/org/springframework/data/solr/core/QueryParser.java
+++ b/src/main/java/org/springframework/data/solr/core/QueryParser.java
@@ -137,6 +137,7 @@ public class QueryParser {
 		appendDefaultOperator(solrQuery, query.getDefaultOperator());
 		appendTimeAllowed(solrQuery, query.getTimeAllowed());
 		appendDefType(solrQuery, query.getDefType());
+		appendRequestHandler(solrQuery, query.getRequestHandler());
 	}
 
 	private void processFacetOptions(SolrQuery solrQuery, FacetQuery query) {
@@ -435,6 +436,12 @@ public class QueryParser {
 	private void appendDefType(SolrQuery solrQuery, String defType) {
 		if (!StringUtils.isEmpty(defType)) {
 			solrQuery.set("defType", defType);
+		}
+	}
+
+	private void appendRequestHandler(SolrQuery solrQuery, String requestHandler) {
+		if (!StringUtils.isEmpty(requestHandler)) {
+			solrQuery.add(CommonParams.QT, requestHandler);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/solr/core/query/Query.java
+++ b/src/main/java/org/springframework/data/solr/core/query/Query.java
@@ -169,4 +169,13 @@ public interface Query extends SolrDataQuery {
 	 */
 	void setDefType(String defType);
 
+	/**
+	 * Returns the request handler.
+	 */
+	String getRequestHandler();
+
+	/**
+	 * Sets the request handler.
+	 */
+	void setRequestHandler(String requestHandler);
 }

--- a/src/main/java/org/springframework/data/solr/core/query/SimpleQuery.java
+++ b/src/main/java/org/springframework/data/solr/core/query/SimpleQuery.java
@@ -43,6 +43,7 @@ public class SimpleQuery extends AbstractQuery implements Query, FilterQuery {
 	private Operator defaultOperator;
 	private Integer timeAllowed;
 	private String defType;
+	private String requestHandler;
 
 	public SimpleQuery() {
 	}
@@ -230,4 +231,13 @@ public class SimpleQuery extends AbstractQuery implements Query, FilterQuery {
 		this.defType = defType;
 	}
 
+	@Override
+	public String getRequestHandler() {
+		return requestHandler;
+	}
+
+	@Override
+	public void setRequestHandler(String requestHandler) {
+		this.requestHandler = requestHandler;
+	}
 }

--- a/src/main/java/org/springframework/data/solr/repository/Query.java
+++ b/src/main/java/org/springframework/data/solr/repository/Query.java
@@ -72,8 +72,15 @@ public @interface Query {
 	String defType() default "";
 
 	/**
+	 * Specifies the request handler {@code qt}
+	 *
+	 * @return
+	 */
+	String requestHandler() default "";
+
+	/**
 	 * The time in milliseconds allowed for a search to finish. Values <= 0 mean no time restriction.
-	 * 
+	 *
 	 * @return
 	 */
 	int timeAllowed() default -1;

--- a/src/main/java/org/springframework/data/solr/repository/query/AbstractSolrQuery.java
+++ b/src/main/java/org/springframework/data/solr/repository/query/AbstractSolrQuery.java
@@ -96,6 +96,7 @@ public abstract class AbstractSolrQuery implements RepositoryQuery {
 		setDefaultQueryOperatorIfDefined(query);
 		setAllowedQueryExeutionTime(query);
 		setDefTypeIfDefined(query);
+		setRequestHandlerIfDefined(query);
 
 		if (solrQueryMethod.isPageQuery()) {
 			if (solrQueryMethod.isFacetQuery()) {
@@ -134,6 +135,13 @@ public abstract class AbstractSolrQuery implements RepositoryQuery {
 		String defType = solrQueryMethod.getDefType();
 		if (StringUtils.hasText(defType)) {
 			query.setDefType(defType);
+		}
+	}
+
+	private void setRequestHandlerIfDefined(Query query) {
+		String requestHandler = solrQueryMethod.getRequestHandler();
+		if (StringUtils.hasText(requestHandler)) {
+			query.setRequestHandler(requestHandler);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/solr/repository/query/SolrQueryMethod.java
+++ b/src/main/java/org/springframework/data/solr/repository/query/SolrQueryMethod.java
@@ -165,6 +165,13 @@ public class SolrQueryMethod extends QueryMethod {
 		return null;
 	}
 
+	public String getRequestHandler() {
+		if (hasQueryAnnotation()) {
+			return getQueryAnnotation().requestHandler();
+		}
+		return null;
+	}
+
 	@SuppressWarnings("unchecked")
 	private List<String> getAnnotationValuesAsStringList(Annotation annotation, String attribute) {
 		String[] values = (String[]) AnnotationUtils.getValue(annotation, attribute);

--- a/src/test/java/org/springframework/data/solr/core/ITestSolrTemplate.java
+++ b/src/test/java/org/springframework/data/solr/core/ITestSolrTemplate.java
@@ -466,4 +466,24 @@ public class ITestSolrTemplate extends AbstractITestWithEmbeddedSolrServer {
 		Page<ExampleSolrBean> page = solrTemplate.queryForPage(query, ExampleSolrBean.class);
 		Assert.assertEquals(3, page.getContent().size());
 	}
+
+	@Test
+	public void testQueryWithRequestHandler() {
+		List<ExampleSolrBean> values = createBeansWithIdAndPrefix(2, "rh-");
+		values.get(0).setInStock(false);
+		values.get(1).setInStock(true);
+
+		solrTemplate.saveBeans(values);
+		solrTemplate.commit();
+
+		SimpleQuery query = new SimpleQuery(new Criteria("id").in("rh-1", "rh-2"));
+		Page<ExampleSolrBean> page = solrTemplate.queryForPage(query, ExampleSolrBean.class);
+		Assert.assertEquals(2, page.getContent().size());
+
+		query = new SimpleQuery(new Criteria("id").in("rh-1", "rh-2"));
+		query.setRequestHandler("/instock");
+		page = solrTemplate.queryForPage(query, ExampleSolrBean.class);
+		Assert.assertEquals(1, page.getContent().size());
+		Assert.assertEquals("rh-2", page.getContent().get(0).getId());
+	}
 }

--- a/src/test/java/org/springframework/data/solr/core/QueryParserTests.java
+++ b/src/test/java/org/springframework/data/solr/core/QueryParserTests.java
@@ -674,6 +674,21 @@ public class QueryParserTests {
 		Assert.assertNull(solrQuery.get("defType"));
 	}
 
+	@Test
+	public void testWithFooRequestHandler() {
+		SimpleQuery query = new SimpleQuery(new SimpleStringCriteria("field_1:value_1"));
+		query.setRequestHandler("/foo");
+		SolrQuery solrQuery = queryParser.constructSolrQuery(query);
+		Assert.assertNotNull(solrQuery.get("qt"));
+	}
+
+	@Test
+	public void testWithUndefinedRequestHandler() {
+		SimpleQuery query = new SimpleQuery(new SimpleStringCriteria("field_1:value_1"));
+		SolrQuery solrQuery = queryParser.constructSolrQuery(query);
+		Assert.assertNull(solrQuery.get("qt"));
+	}
+
 	private void assertFactingPresent(SolrQuery solrQuery, String... expected) {
 		Assert.assertArrayEquals(expected, solrQuery.getFacetFields());
 	}

--- a/src/test/java/org/springframework/data/solr/repository/ProductRepository.java
+++ b/src/test/java/org/springframework/data/solr/repository/ProductRepository.java
@@ -142,4 +142,7 @@ public interface ProductRepository extends SolrCrudRepository<ProductBean, Strin
 	@Query(defType = "lucene")
 	List<ProductBean> findByNameIn(Collection<String> name);
 
+	@Query(requestHandler = "/instock")
+	List<ProductBean> findByText(String text);
+
 }

--- a/src/test/java/org/springframework/data/solr/repository/query/SolrQueryMethodTests.java
+++ b/src/test/java/org/springframework/data/solr/repository/query/SolrQueryMethodTests.java
@@ -247,6 +247,12 @@ public class SolrQueryMethodTests {
 		Assert.assertEquals("lucene", method.getDefType());
 	}
 
+	@Test
+	public void testQueryWithRequestHandler() throws Exception {
+		SolrQueryMethod method = getQueryMethodByName("findByText", String.class);
+		Assert.assertEquals("/instock", method.getRequestHandler());
+	}
+
 	private SolrQueryMethod getQueryMethodByName(String name, Class<?>... parameters) throws Exception {
 		Method method = Repo1.class.getMethod(name, parameters);
 		return new SolrQueryMethod(method, new DefaultRepositoryMetadata(Repo1.class), creator);
@@ -306,6 +312,9 @@ public class SolrQueryMethodTests {
 
 		@Query(defType = "lucene")
 		List<ProductBean> findByNameEndingWith(String name);
+
+		@Query(requestHandler = "/instock")
+		List<ProductBean> findByText(String text);
 	}
 
 }

--- a/src/test/resources/org/springframework/data/solr/conf/solrconfig.xml
+++ b/src/test/resources/org/springframework/data/solr/conf/solrconfig.xml
@@ -809,6 +809,17 @@
       -->
     </requestHandler>
 
+  <requestHandler name="/instock" class="solr.SearchHandler">
+     <lst name="defaults">
+       <str name="echoParams">explicit</str>
+       <int name="rows">10</int>
+       <str name="df">text</str>
+     </lst>
+     <lst name="appends">
+       <str name="fq">inStock:true</str>
+     </lst>
+  </requestHandler>
+
   <!-- A request handler that returns indented JSON by default -->
   <requestHandler name="/query" class="solr.SearchHandler">
      <lst name="defaults">


### PR DESCRIPTION
https://jira.springsource.org/browse/DATASOLR-65

Handler can be added to query via annotation, e.g.

```
@Query(requestHandler = "/instock")
```
