### PR TITLE
DATASOLR-95 - introduced maxScore property to SolrResultPage

### DIFF
--- a/src/main/java/org/springframework/data/solr/core/ResultHelper.java
+++ b/src/main/java/org/springframework/data/solr/core/ResultHelper.java
@@ -113,10 +113,10 @@ final class ResultHelper {
 							}
 						}
 						facetResult.put(field, new SolrResultPage<FacetFieldEntry>(pageEntries, query.getFacetOptions()
-								.getPageable(), facetField.getValueCount()));
+								.getPageable(), facetField.getValueCount(), null));
 					} else {
 						facetResult.put(field, new SolrResultPage<FacetFieldEntry>(Collections.<FacetFieldEntry> emptyList(), query
-								.getFacetOptions().getPageable(), 0));
+								.getFacetOptions().getPageable(), 0, null));
 					}
 				}
 			}

--- a/src/main/java/org/springframework/data/solr/core/SolrOperations.java
+++ b/src/main/java/org/springframework/data/solr/core/SolrOperations.java
@@ -30,6 +30,7 @@ import org.springframework.data.solr.core.query.SolrDataQuery;
 import org.springframework.data.solr.core.query.TermsQuery;
 import org.springframework.data.solr.core.query.result.FacetPage;
 import org.springframework.data.solr.core.query.result.HighlightPage;
+import org.springframework.data.solr.core.query.result.ScoredPage;
 import org.springframework.data.solr.core.query.result.TermsPage;
 
 /**
@@ -170,7 +171,7 @@ public interface SolrOperations {
 	 * @param clazz
 	 * @return
 	 */
-	<T> Page<T> queryForPage(Query query, Class<T> clazz);
+	<T> ScoredPage<T> queryForPage(Query query, Class<T> clazz);
 
 	/**
 	 * Execute a facet query against solr facet result will be returned along with query result within the FacetPage

--- a/src/main/java/org/springframework/data/solr/core/query/result/ScoredPage.java
+++ b/src/main/java/org/springframework/data/solr/core/query/result/ScoredPage.java
@@ -1,0 +1,21 @@
+package org.springframework.data.solr.core.query.result;
+
+import org.springframework.data.domain.Page;
+
+/**
+ * Specific type of {@link Page} holding max score information.
+ * 
+ * @author Francisco Spaeth
+ *
+ * @param <T>
+ */
+public interface ScoredPage<T> extends Page<T> {
+
+	/**
+	 * Returns the scoring of the topmost document (max score).
+	 * 
+	 * @return
+	 */
+	Float getMaxScore();
+	
+}

--- a/src/main/java/org/springframework/data/solr/core/query/result/SolrResultPage.java
+++ b/src/main/java/org/springframework/data/solr/core/query/result/SolrResultPage.java
@@ -39,7 +39,7 @@ import org.springframework.util.ObjectUtils;
  * @author Francisco Spaeth
  * 
  */
-public class SolrResultPage<T> extends PageImpl<T> implements FacetPage<T>, HighlightPage<T> {
+public class SolrResultPage<T> extends PageImpl<T> implements FacetPage<T>, HighlightPage<T>, ScoredPage<T> {
 
 	private static final long serialVersionUID = -4199560685036530258L;
 
@@ -47,13 +47,15 @@ public class SolrResultPage<T> extends PageImpl<T> implements FacetPage<T>, High
 	private Map<PageKey, List<FacetPivotFieldEntry>> facetPivotResultPages = new LinkedHashMap<PageKey, List<FacetPivotFieldEntry>>();
 	private Page<FacetQueryEntry> facetQueryResult;
 	private List<HighlightEntry<T>> highlighted;
+	private Float maxScore;
 
 	public SolrResultPage(List<T> content) {
 		super(content);
 	}
 
-	public SolrResultPage(List<T> content, Pageable pageable, long total) {
+	public SolrResultPage(List<T> content, Pageable pageable, long total, Float maxScore) {
 		super(content, pageable, total);
+		this.maxScore = maxScore;
 	}
 
 	@Override
@@ -167,5 +169,10 @@ public class SolrResultPage<T> extends PageImpl<T> implements FacetPage<T>, High
 		}
 		return Collections.emptyList();
 	}
-
+	
+	@Override
+	public Float getMaxScore() {
+		return maxScore;
+	}
+	
 }

--- a/src/test/java/org/springframework/data/solr/repository/support/ITestSolrRepositoryFactory.java
+++ b/src/test/java/org/springframework/data/solr/repository/support/ITestSolrRepositoryFactory.java
@@ -29,6 +29,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.solr.AbstractITestWithEmbeddedSolrServer;
 import org.springframework.data.solr.core.SolrTemplate;
+import org.springframework.data.solr.core.query.result.ScoredPage;
 import org.springframework.data.solr.repository.ProductBean;
 import org.springframework.data.solr.repository.Query;
 import org.springframework.data.solr.repository.SolrCrudRepository;
@@ -96,6 +97,18 @@ public class ITestSolrRepositoryFactory extends AbstractITestWithEmbeddedSolrSer
 	}
 
 	@Test
+	public void testScoredAnnotatedQuery() {
+		ProductBean initial = createProductBean("1");
+
+		ProductBeanRepository repository = factory.getRepository(ProductBeanRepository.class);
+		repository.save(initial);
+
+		ScoredPage<ProductBean> result = repository.findByAnnotatedQuery1("na", new PageRequest(0, 5));
+		Assert.assertEquals(1, result.getContent().size());
+		Assert.assertEquals(Float.valueOf(1), result.getMaxScore());
+	}
+
+	@Test
 	public void testPartTreeQuery() {
 		ProductBean availableProduct = createProductBean("1");
 		ProductBean unavailableProduct = createProductBean("2");
@@ -160,6 +173,9 @@ public class ITestSolrRepositoryFactory extends AbstractITestWithEmbeddedSolrSer
 
 		@Query("id:?0")
 		ProductBean findSingleElement(String id);
+		
+		@Query(value = "name:?0*", fields = {"*","score"})
+		ScoredPage<ProductBean> findByAnnotatedQuery1(String prefix, Pageable page);
 
 	}
 


### PR DESCRIPTION
The proposed change creates a new interface named `ScoredPage<T>` that extends `Page<T>` and exposes the maxScore for a given query result. `SolrOperations` was modified to deliver a `ScoredPage<T>` instead of `Page<T>`.
