### PR TITLE
DATASOLR-139 - Combination of OR | AND are not fully captured within SolrQueryCreator. 

### DIFF
--- a/src/main/java/org/springframework/data/solr/core/query/Criteria.java
+++ b/src/main/java/org/springframework/data/solr/core/query/Criteria.java
@@ -195,9 +195,17 @@ public class Criteria {
 	public Criteria or(Criteria criteria) {
 		Assert.notNull(criteria, "Cannot chain 'null' criteria.");
 
-		Criteria orConnectedCritiera = new OrCriteria(this.criteriaChain, criteria.getField());
-		orConnectedCritiera.criteria.addAll(criteria.criteria);
-		return orConnectedCritiera;
+		Criteria orConnectedCriteria = new OrCriteria(this.criteriaChain, criteria.getField());
+		orConnectedCriteria.criteria.addAll(criteria.criteria);
+		
+		for (Criteria c : criteria.getCriteriaChain()) {
+			if (c == criteria) {
+				continue;
+			}
+			orConnectedCriteria.and(c);
+		}
+
+		return orConnectedCriteria;
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/solr/repository/query/SolrQueryCreatorTests.java
+++ b/src/test/java/org/springframework/data/solr/repository/query/SolrQueryCreatorTests.java
@@ -368,7 +368,19 @@ public class SolrQueryCreatorTests {
 		Assert.assertEquals(Sort.Direction.DESC, query.getSort().getOrderFor("title").getDirection());
 	}
 
-	private Query createQueryForMethodWithArgs(Method method, Object[] args) {
+	  @Test
+	  public void testCombinationsOfOrAndShouldBeCreatedCorrectly() throws NoSuchMethodException, SecurityException {
+
+	    Method method = SampleRepository.class.getMethod("findByNameOrDescriptionAndLastModifiedAfter", String.class,
+	        String.class, Date.class);
+
+	    Query query = createQueryForMethodWithArgs(method, new Object[] { "mail", "domain",
+	        new DateTime(2012, 10, 15, 5, 31, 0, DateTimeZone.UTC) });
+	    Assert.assertEquals("name:mail OR description:domain AND last_modified:{2012\\-10\\-15T05\\:31\\:00.000Z TO *]",
+	        queryParser.getQueryString(query));
+	  }
+	  
+	  private Query createQueryForMethodWithArgs(Method method, Object[] args) {
 		PartTree partTree = new PartTree(method.getName(), method.getReturnType());
 		SolrQueryMethod queryMethod = new SolrQueryMethod(method, metadataMock, entityInformationCreatorMock);
 		SolrQueryCreator creator = new SolrQueryCreator(partTree, new SolrParametersParameterAccessor(queryMethod, args),
@@ -448,6 +460,8 @@ public class SolrQueryCreatorTests {
 		ProductBean findByLocationNear(GeoLocation location, Distance distance);
 
 		ProductBean findByLocationNear(BoundingBox bbox);
+		
+		ProductBean findByNameOrDescriptionAndLastModifiedAfter(String name, String description, Date date);
 
 	}
 


### PR DESCRIPTION
The problem was the criterias that were already on criteriaChain were not being added when creating an OrCriteria using another Criteria. The proposed solution adds existent criteria-chain's criterias to OrCriteria when invoking org.springframework.data.solr.core.query.Criteria.or(Criteria).
