### PR TITLE
Improved support for DisMax and eDisMax query parsers

### DIFF
--- a/src/main/java/org/springframework/data/solr/core/DefaultQueryParser.java
+++ b/src/main/java/org/springframework/data/solr/core/DefaultQueryParser.java
@@ -95,6 +95,7 @@ public class DefaultQueryParser extends QueryParserBase<SolrDataQuery> {
 		appendDefaultOperator(solrQuery, query.getDefaultOperator());
 		appendTimeAllowed(solrQuery, query.getTimeAllowed());
 		appendDefType(solrQuery, query.getDefType());
+		appendQueryFields(solrQuery, query.getQueryFields());
 		appendRequestHandler(solrQuery, query.getRequestHandler());
 	}
 

--- a/src/main/java/org/springframework/data/solr/core/QueryParserBase.java
+++ b/src/main/java/org/springframework/data/solr/core/QueryParserBase.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServer;
 import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.DisMaxParams;
 import org.apache.solr.common.params.SpatialParams;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.support.GenericConversionService;
@@ -353,6 +354,16 @@ public abstract class QueryParserBase<QUERYTPYE extends SolrDataQuery> implement
 		if (StringUtils.isNotBlank(defType)) {
 			solrQuery.set("defType", defType);
 		}
+	}
+
+	/**
+	 * Appends the DisMax / eDisMax query fields to the given Solr query.
+	 *
+	 * @param solrQuery
+	 * @param queryFields
+	 */
+	protected void appendQueryFields(SolrQuery solrQuery, List<String> queryFields) {
+		solrQuery.set(DisMaxParams.QF, StringUtils.trimToNull(StringUtils.join(queryFields, ' ')));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/solr/core/query/Query.java
+++ b/src/main/java/org/springframework/data/solr/core/query/Query.java
@@ -95,6 +95,14 @@ public interface Query extends SolrDataQuery {
 	<T extends Query> T setTimeAllowed(Integer timeAllowed);
 
 	/**
+	 * Sets the fields to query in a DisMax or eDisMax query
+	 *
+	 * @param queryFields the fields to match against
+	 * @return the updated query
+	 */
+	<T extends Query> T setQueryFields(List<String> queryFields);
+
+	/**
 	 * Get filter queries if defined
 	 * 
 	 * @return
@@ -121,6 +129,13 @@ public interface Query extends SolrDataQuery {
 	 * @return
 	 */
 	List<Field> getProjectionOnFields();
+
+	/**
+	 * Get query fields if defined
+	 *
+	 * @return a list of query fields if defined; and empty list otherwise
+	 */
+	List<String> getQueryFields();
 
 	/**
 	 * Add {@link Sort} to query

--- a/src/main/java/org/springframework/data/solr/core/query/SimpleQuery.java
+++ b/src/main/java/org/springframework/data/solr/core/query/SimpleQuery.java
@@ -44,6 +44,7 @@ public class SimpleQuery extends AbstractQuery implements Query, FilterQuery {
 	private Operator defaultOperator;
 	private Integer timeAllowed;
 	private String defType;
+	private List<String> queryFields = Collections.emptyList();
 
 	public SimpleQuery() {}
 
@@ -280,4 +281,17 @@ public class SimpleQuery extends AbstractQuery implements Query, FilterQuery {
 		this.defType = defType;
 	}
 
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T extends Query> T setQueryFields(List<String> queryFields) {
+		Assert.notNull(queryFields, "Query fields cannot be null");
+		Assert.notEmpty(queryFields, "Query fields cannot be empty");
+		this.queryFields = new ArrayList<String>(queryFields);
+		return (T) this;
+	}
+
+	@Override
+	public List<String> getQueryFields() {
+		return Collections.unmodifiableList(queryFields);
+	}
 }

--- a/src/main/java/org/springframework/data/solr/repository/Query.java
+++ b/src/main/java/org/springframework/data/solr/repository/Query.java
@@ -73,6 +73,13 @@ public @interface Query {
 	String defType() default "";
 
 	/**
+	 * Specifies the query fields for a "dismax" or "edismax" query {@code qf}
+	 *
+	 * @see #defType()
+	 */
+	String[] queryFields() default {};
+
+	/**
 	 * Specifies the request handler {@code qt}
 	 * 
 	 * @return

--- a/src/main/java/org/springframework/data/solr/repository/query/AbstractSolrQuery.java
+++ b/src/main/java/org/springframework/data/solr/repository/query/AbstractSolrQuery.java
@@ -16,6 +16,7 @@
 package org.springframework.data.solr.repository.query;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -110,6 +111,7 @@ public abstract class AbstractSolrQuery implements RepositoryQuery {
 		setDefaultQueryOperatorIfDefined(query);
 		setAllowedQueryExeutionTime(query);
 		setDefTypeIfDefined(query);
+		setQueryFields(query);
 		setRequestHandlerIfDefined(query);
 
 		if (isCountQuery()) {
@@ -161,6 +163,13 @@ public abstract class AbstractSolrQuery implements RepositoryQuery {
 		String defType = solrQueryMethod.getDefType();
 		if (StringUtils.hasText(defType)) {
 			query.setDefType(defType);
+		}
+	}
+
+	private void setQueryFields(Query query) {
+		List<String> queryFields = solrQueryMethod.getQueryFields();
+		if (!queryFields.isEmpty()) {
+			query.setQueryFields(queryFields);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/solr/repository/query/SolrQueryMethod.java
+++ b/src/main/java/org/springframework/data/solr/repository/query/SolrQueryMethod.java
@@ -324,6 +324,20 @@ public class SolrQueryMethod extends QueryMethod {
 	}
 
 	/**
+	 * Returns the query fields specified in {@link Query#queryFields()} if set;
+	 * an empty list otherwise.
+	 *
+	 * @return a list of query fields specified in {@link Query#queryFields()} if set;
+	 * an empty list otherwise.
+	 */
+	public List<String> getQueryFields() {
+		if (hasQueryAnnotation()) {
+			return getAnnotationValuesAsStringList(getQueryAnnotation(), "queryFields");
+		}
+		return Collections.emptyList();
+	}
+
+	/**
 	 * @return null if {@link Query#requestHandler()} not set
 	 */
 	public String getRequestHandler() {

--- a/src/test/java/org/springframework/data/solr/core/DefaultQueryParserTests.java
+++ b/src/test/java/org/springframework/data/solr/core/DefaultQueryParserTests.java
@@ -67,6 +67,7 @@ import org.springframework.data.solr.core.query.SimpleStringCriteria;
  * @author Andrey Paramonov
  * @author Philipp Jardas
  * @author Francisco Spaeth
+ * @author Scott Rossillo
  */
 public class DefaultQueryParserTests {
 
@@ -875,6 +876,20 @@ public class DefaultQueryParserTests {
 		SimpleQuery query = new SimpleQuery(new SimpleStringCriteria("field_1:value_1"));
 		SolrQuery solrQuery = queryParser.constructSolrQuery(query);
 		Assert.assertNull(solrQuery.get("defType"));
+	}
+
+	@Test
+	public void testWithQueryFields() {
+		SimpleQuery query = new SimpleQuery(new SimpleStringCriteria("value_1")).setQueryFields(Arrays.asList("foo", "bar"));
+		SolrQuery solrQuery = queryParser.constructSolrQuery(query);
+		Assert.assertNotNull(solrQuery.get("qf"));
+		Assert.assertEquals("foo bar", solrQuery.get("qf"));
+	}
+	@Test
+	public void testWithUndefinedQueryFields() {
+		SimpleQuery query = new SimpleQuery(new SimpleStringCriteria("value_1"));
+		SolrQuery solrQuery = queryParser.constructSolrQuery(query);
+		Assert.assertNull(solrQuery.get("qf"));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/solr/core/query/SimpleQueryTests.java
+++ b/src/test/java/org/springframework/data/solr/core/query/SimpleQueryTests.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.solr.core.query;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -68,6 +71,23 @@ public class SimpleQueryTests {
 		Query query = new SimpleQuery().addProjectionOnField(new SimpleField("field_1")).addProjectionOnField(
 				new SimpleField("field_2"));
 		Assert.assertEquals(2, ((List) query.getProjectionOnFields()).size());
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Test
+	public void testSetQueryFields() {
+		Query query = new SimpleQuery().setQueryFields(Arrays.asList("foo", "bar"));
+		Assert.assertEquals(2, ((List) query.getQueryFields()).size());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSetQueryFieldsNull() {
+		new SimpleQuery().setQueryFields(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testSetQueryFieldsEmptyList() {
+		new SimpleQuery().setQueryFields(new ArrayList<String>(0));
 	}
 
 	@Test


### PR DESCRIPTION
Added support for specifying query fields for the DisMax and eDisMax query parsers.  See [DATASOLR-153](https://jira.spring.io/browse/DATASOLR-153) for more information.
