### PR TITLE
DATASOLR-146 - Prelare release for 1.2.0.M1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.4.0.BUILD-SNAPSHOT</version>
+		<version>1.4.0.M1</version>
 		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
 	</parent>
 
@@ -24,7 +24,7 @@
 		<commons.lang>3.1</commons.lang>
 		<httpcomponents>4.2.2</httpcomponents>
 		<solr>4.7.0</solr>
-		<springdata.commons>1.8.0.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.8.0.M1</springdata.commons>
 	</properties>
 	
 	<developers>
@@ -62,14 +62,6 @@
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-tx</artifactId>
 			<version>${spring}</version>
-		</dependency>
-
-		<!-- For JavaConfig -->
-		<dependency>
-			<groupId>cglib</groupId>
-			<artifactId>cglib</artifactId>
-			<version>2.2.2</version>
-			<scope>test</scope>
 		</dependency>
 
 		<!-- SPRING DATA -->
@@ -252,7 +244,7 @@
 
 	<issueManagement>
 		<system>JIRA</system>
-		<url>https://jira.springsource.org/browse/DATASOLR</url>
+		<url>https://jira.spring.io/browse/DATASOLR</url>
 	</issueManagement>
 
 	<scm>
@@ -263,13 +255,13 @@
 
 	<ciManagement>
 		<system>Bamboo</system>
-		<url>http://build.springsource.org/browse/DATASOLR</url>
+		<url>http://build.spring.io/browse/DATASOLR</url>
 	</ciManagement>
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>http://repo.spring.io/libs-snapshot/</url>
+			<id>spring-libs-milestone</id>
+			<url>http://repo.spring.io/libs-milestone/</url>
 		</repository>
 	</repositories>
 	

--- a/src/docbkx/index.xml
+++ b/src/docbkx/index.xml
@@ -47,7 +47,7 @@
 	<part id="reference">
 		<title>Reference Documentation</title>
 
-		<xi:include href="https://raw.github.com/spring-projects/spring-data-commons/1.7.0.RELEASE/src/docbkx/repositories.xml">
+		<xi:include href="https://raw.github.com/spring-projects/spring-data-commons/1.8.0.M1/src/docbkx/repositories.xml">
 			<xi:fallback href="../../../spring-data-commons/src/docbkx/repositories.xml" /> 
 		</xi:include>
 
@@ -58,12 +58,12 @@
 	<part id="appendix">
 		<title>Appendix</title>
 		<xi:include
-			href="https://raw.github.com/spring-projects/spring-data-commons/1.7.0.RELEASE/src/docbkx/repository-namespace-reference.xml">
+			href="https://raw.github.com/spring-projects/spring-data-commons/1.8.0.M1/src/docbkx/repository-namespace-reference.xml">
 			<xi:fallback
 				href="../../../spring-data-commons/src/docbkx/repository-namespace-reference.xml" />
 		</xi:include>
 		<xi:include
-			href="https://raw.github.com/spring-projects/spring-data-commons/1.7.0.RELEASE/src/docbkx/repository-query-keywords-reference.xml">
+			href="https://raw.github.com/spring-projects/spring-data-commons/1.8.0.M1/src/docbkx/repository-query-keywords-reference.xml">
 			<xi:fallback
 				href="../../../spring-data-commons/src/docbkx/repository-query-keywords-reference.xml" />
 		</xi:include>

--- a/src/docbkx/preface.xml
+++ b/src/docbkx/preface.xml
@@ -24,7 +24,7 @@
 			<listitem>
 				<para>
 					Bugtacker -
-					<ulink url="https://jira.springsource.org/browse/DATASOLR">https://jira.springsource.org/browse/DATASOLR
+					<ulink url="https://jira.spring.io/browse/DATASOLR">https://jira.spring.io/browse/DATASOLR
 					</ulink>
 				</para>
 			</listitem>

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,3 +1,23 @@
+Release Notes - Spring Data Solr - Version 1.2 M1 (Dijkstra)
+---------------------------------------------------------
+** Fix
+    * [DATASOLR-105] - Allow nesting of chained Criteria.
+
+** New Feature
+    * [DATASOLR-88] - Support for index time boost on managed entites. (kudos @franciscospaeth)
+    * [DATASOLR-143] - Add support for 'countBy' queries.
+    * [DATASOLR-144] - Add support for derived 'deleteBy...' queries.
+    
+** Task
+    * [DATASOLR-142] - Support geo structures from spring-data-commons.
+    * [DATASOLR-147] - Upgrade to Solr 4.7
+    * [DATASOLR-152] - Adapt changes on property information from sd-commons.
+    * [DATASOLR-154] - Remove obsolete generics from BeanWrapper.
+
+Release Notes - Spring Data Solr - Version 1.1.1 GA (Codd)
+---------------------------------------------------------
+** No issues filed for 1.1.1 GA (Codd)
+
 Release Notes - Spring Data Solr - Version 1.1 GA (Codd)
 ---------------------------------------------------------
 ** Fix

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Solr 1.1 GA
+Spring Data Solr 1.2 M1
 Copyright (c) [2013-2014] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").  


### PR DESCRIPTION
Update readme, notice and changelog.
Update pom.xml to point to recent sd-commons version.
Update pom.xml to point to spring milestone repository.
