### PR TITLE
DATASOLR-155 - improved pivot facet annotation syntax

### DIFF
--- a/src/main/java/org/springframework/data/solr/repository/Facet.java
+++ b/src/main/java/org/springframework/data/solr/repository/Facet.java
@@ -80,8 +80,18 @@ public @interface Facet {
 	 * fields to pivot on
 	 * 
 	 * @return
+	 * @deprecated use {@link #pivots()} instead
 	 */
 	String[] pivotFields() default {};
+
+	/**
+	 * {@code facet.pivot}
+	 * 
+	 * fields to pivot on
+	 * 
+	 * @return
+	 */
+	Pivot[] pivots() default {};
 
 	/**
 	 * {@code facet.pivot.mincount}

--- a/src/main/java/org/springframework/data/solr/repository/Pivot.java
+++ b/src/main/java/org/springframework/data/solr/repository/Pivot.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012 - 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.repository;
+
+/**
+ * @author Francisco Spaeth
+ * 
+ */
+public @interface Pivot {
+
+	/**
+	 * {@code facet.pivot}
+	 * 
+	 * definition of a pivot field
+	 * 
+	 * @return
+	 */
+	String[] value() default {};
+
+}

--- a/src/main/java/org/springframework/data/solr/repository/query/AbstractSolrQuery.java
+++ b/src/main/java/org/springframework/data/solr/repository/query/AbstractSolrQuery.java
@@ -257,7 +257,7 @@ public abstract class AbstractSolrQuery implements RepositoryQuery {
 			}
 		}
 		if (queryMethod.hasPivotFields()) {
-			for (String pivot : queryMethod.getPivotFields()) {
+			for (String[] pivot : queryMethod.getPivotFields()) {
 				options.addFacetOnPivot(pivot);
 			}
 		}

--- a/src/main/java/org/springframework/data/solr/repository/query/SolrQueryMethod.java
+++ b/src/main/java/org/springframework/data/solr/repository/query/SolrQueryMethod.java
@@ -17,6 +17,7 @@ package org.springframework.data.solr.repository.query;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -25,6 +26,7 @@ import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.query.QueryMethod;
 import org.springframework.data.solr.repository.Facet;
 import org.springframework.data.solr.repository.Highlight;
+import org.springframework.data.solr.repository.Pivot;
 import org.springframework.data.solr.repository.Query;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
@@ -157,8 +159,20 @@ public class SolrQueryMethod extends QueryMethod {
 		return getAnnotationValuesAsStringList(getFacetAnnotation(), "queries");
 	}
 
-	public List<String> getPivotFields() {
-		return getAnnotationValuesAsStringList(getFacetAnnotation(), "pivotFields");
+	public List<String[]> getPivotFields() {
+		List<String> stringPivotFields = getAnnotationValuesAsStringList(getFacetAnnotation(), "pivotFields");
+		List<Pivot> pivotFields = getAnnotationValuesList(getFacetAnnotation(), "pivots", Pivot.class);
+		ArrayList<String[]> result = new ArrayList<String[]>();
+		
+		for (String str : stringPivotFields) {
+			result.add(StringUtils.split(str, ","));
+		}
+		
+		for (Pivot pivot : pivotFields) {
+			result.add(pivot.value());
+		}
+		
+		return result;
 	}
 
 	/**
@@ -366,6 +380,12 @@ public class SolrQueryMethod extends QueryMethod {
 		return Collections.emptyList();
 	}
 
+	@SuppressWarnings("unchecked")
+	private <T> List<T> getAnnotationValuesList(Facet annotation,	String attribute, Class<T> clazz) {
+		T[] values = (T[]) AnnotationUtils.getValue(annotation, attribute);
+		return CollectionUtils.arrayToList(values);
+	}
+	
 	@Override
 	public String getNamedQueryName() {
 		if (!hasAnnotatedNamedQueryName()) {

--- a/src/test/java/org/springframework/data/solr/repository/query/SolrQueryMethodTests.java
+++ b/src/test/java/org/springframework/data/solr/repository/query/SolrQueryMethodTests.java
@@ -29,6 +29,7 @@ import org.springframework.data.repository.core.support.DefaultRepositoryMetadat
 import org.springframework.data.solr.core.mapping.SimpleSolrMappingContext;
 import org.springframework.data.solr.repository.Facet;
 import org.springframework.data.solr.repository.Highlight;
+import org.springframework.data.solr.repository.Pivot;
 import org.springframework.data.solr.repository.ProductBean;
 import org.springframework.data.solr.repository.Query;
 import org.springframework.data.solr.repository.support.SolrEntityInformationCreatorImpl;
@@ -166,6 +167,32 @@ public class SolrQueryMethodTests {
 	@Test
 	public void testWithMultipleFieldPivot() throws Exception {
 		SolrQueryMethod method = getQueryMethodByName("findByNamePivotOnField1VsField2AndField2VsField3");
+		Assert.assertFalse(method.hasAnnotatedQuery());
+		Assert.assertFalse(method.hasProjectionFields());
+		Assert.assertFalse(method.hasFacetFields());
+		Assert.assertTrue(method.hasPivotFields());
+		Assert.assertFalse(method.hasFacetQueries());
+		Assert.assertEquals(2, method.getPivotFields().size());
+		Assert.assertFalse(method.hasAnnotatedNamedQueryName());
+		Assert.assertFalse(method.hasFilterQuery());
+	}
+
+	@Test
+	public void testWithMultipleFieldPivotUsingPivotAnnotation() throws Exception {
+		SolrQueryMethod method = getQueryMethodByName("findByNamePivotOnField1VsField2AndField2VsField3UsingPivotAnnotation");
+		Assert.assertFalse(method.hasAnnotatedQuery());
+		Assert.assertFalse(method.hasProjectionFields());
+		Assert.assertFalse(method.hasFacetFields());
+		Assert.assertTrue(method.hasPivotFields());
+		Assert.assertFalse(method.hasFacetQueries());
+		Assert.assertEquals(4, method.getPivotFields().size());
+		Assert.assertFalse(method.hasAnnotatedNamedQueryName());
+		Assert.assertFalse(method.hasFilterQuery());
+	}
+
+	@Test
+	public void testWithMultipleFieldPivotUsingOnlyPivotAnnotation() throws Exception {
+		SolrQueryMethod method = getQueryMethodByName("findByNamePivotOnField1VsField2AndField2VsField3UsingOnlyPivotAnnotation");
 		Assert.assertFalse(method.hasAnnotatedQuery());
 		Assert.assertFalse(method.hasProjectionFields());
 		Assert.assertFalse(method.hasFacetFields());
@@ -521,6 +548,12 @@ public class SolrQueryMethodTests {
 
 		@Facet(pivotFields = { "field1,field2", "field2,field3" }, minCount = 3, limit = 25)
 		List<ProductBean> findByNamePivotOnField1VsField2AndField2VsField3AndLimitAndMinCount();
+
+		@Facet(pivotFields = { "field1,field2", "field2,field3" }, pivots = { @Pivot("field4,field5"), @Pivot("field5,field6") })
+		List<ProductBean> findByNamePivotOnField1VsField2AndField2VsField3UsingPivotAnnotation();
+
+		@Facet(pivots = { @Pivot("field1,field2"), @Pivot("field2,field3") })
+		List<ProductBean> findByNamePivotOnField1VsField2AndField2VsField3UsingOnlyPivotAnnotation();
 
 	}
 


### PR DESCRIPTION
deprecated pivotFields from @Facet in favor of pivots using @Pivot to
define pivot fields.
