### PR TITLE
DATASOLR-210 - Add @Score annotation marking a property as readonly and automatically add projection on score when present.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-solr</artifactId>
-	<version>1.4.0.BUILD-SNAPSHOT</version>
+	<version>1.4.0.DATASOLR-210-SNAPSHOT</version>
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>

--- a/src/main/asciidoc/reference/misc.adoc
+++ b/src/main/asciidoc/reference/misc.adoc
@@ -483,3 +483,28 @@ Collection<String> ids = Arrays.asList("123", "134");
 Collection<Product> products = solrTemplate.getById(ids, Product.class);
 ----
 ====
+
+[[solr.misc.specialFields]]
+== Special Fields
+
+=== @Score
+
+In order to load score information of a query result, a field annotated with `@Score` annotation could be added, indicating where 
+shall be the score information loaded to.
+
+====
+[source,java]
+----
+public class MyEntity {
+
+    @Id
+    private String id;
+    
+    @Score
+    private Float score;
+    
+    // setters and getters ...
+
+}	            
+----
+====

--- a/src/main/java/org/springframework/data/solr/core/convert/MappingSolrConverter.java
+++ b/src/main/java/org/springframework/data/solr/core/convert/MappingSolrConverter.java
@@ -319,7 +319,15 @@ public class MappingSolrConverter extends SolrConverterBase implements SolrConve
 			if (property.containsWildcard()) {
 				return (T) readWildcard(value, property, parent);
 			}
+			if (property.isScoreProperty()) {
+				return (T) readScore(value, property, parent);
+			}
 			return readValue(value.get(property.getFieldName()), property.getTypeInformation(), parent);
+		}
+
+		@SuppressWarnings("unchecked")
+		private <T> T readScore(Map<String, ?> value, SolrPersistentProperty property, Object parent) {
+			return (T) value.get("score");
 		}
 
 		@SuppressWarnings("unchecked")

--- a/src/main/java/org/springframework/data/solr/core/mapping/SimpleSolrPersistentProperty.java
+++ b/src/main/java/org/springframework/data/solr/core/mapping/SimpleSolrPersistentProperty.java
@@ -27,6 +27,7 @@ import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.model.AnnotationBasedPersistentProperty;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.solr.core.query.Criteria;
+import org.springframework.data.solr.repository.Score;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
@@ -90,6 +91,10 @@ public class SimpleSolrPersistentProperty extends AnnotationBasedPersistentPrope
 
 		if (isIdProperty() || isVersionProperty()) {
 			return false;
+		}
+
+		if (isScoreProperty()) {
+			return true;
 		}
 
 		Indexed indexedAnnotation = getIndexAnnotation();
@@ -274,4 +279,10 @@ public class SimpleSolrPersistentProperty extends AnnotationBasedPersistentPrope
 		Indexed indexedAnnotation = getIndexAnnotation();
 		return indexedAnnotation != null && indexedAnnotation.required();
 	}
+
+	@Override
+	public boolean isScoreProperty() {
+		return findAnnotation(Score.class) != null;
+	}
+
 }

--- a/src/main/java/org/springframework/data/solr/core/mapping/SimpleSolrPersistentProperty.java
+++ b/src/main/java/org/springframework/data/solr/core/mapping/SimpleSolrPersistentProperty.java
@@ -93,10 +93,6 @@ public class SimpleSolrPersistentProperty extends AnnotationBasedPersistentPrope
 			return false;
 		}
 
-		if (isScoreProperty()) {
-			return true;
-		}
-
 		Indexed indexedAnnotation = getIndexAnnotation();
 		if (indexedAnnotation != null && indexedAnnotation.readonly()) {
 			return true;

--- a/src/main/java/org/springframework/data/solr/core/mapping/SolrPersistentEntity.java
+++ b/src/main/java/org/springframework/data/solr/core/mapping/SolrPersistentEntity.java
@@ -16,6 +16,7 @@
 package org.springframework.data.solr.core.mapping;
 
 import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.PersistentProperty;
 
 /**
  * @param <T>
@@ -30,15 +31,42 @@ public interface SolrPersistentEntity<T> extends PersistentEntity<T, SolrPersist
 	 * @return
 	 */
 	String getSolrCoreName();
-	
+
 	/**
 	 * @return true if this entity is boosted
 	 */
 	boolean isBoosted();
-	
+
 	/**
 	 * @return entity's boost value if {@link #isBoosted()}, null otherwise
 	 */
 	Float getBoost();
+
+	/**
+	 * Returns whether the {@link SolrPersistentEntity} has an score property. If this call returns {@literal true},
+	 * {@link #getScoreProperty()} will return a non-{@literal null} value.
+	 * 
+	 * @return
+	 * @since 1.4
+	 */
+	boolean hasScoreProperty();
+
+	/**
+	 * Returns the score property of the {@link SolrPersistentEntity}. Can be {@literal null} in case no score property is
+	 * available on the entity.
+	 * 
+	 * @return the score property of the {@link PersistentEntity}.
+	 * @since 1.4
+	 */
+	SolrPersistentProperty getScoreProperty();
+
+	/**
+	 * Returns whether the given {@link PersistentProperty} is the score property of the entity.
+	 * 
+	 * @param property
+	 * @return
+	 * @since 1.4
+	 */
+	boolean isScoreProperty(SolrPersistentProperty property);
 
 }

--- a/src/main/java/org/springframework/data/solr/core/mapping/SolrPersistentProperty.java
+++ b/src/main/java/org/springframework/data/solr/core/mapping/SolrPersistentProperty.java
@@ -18,6 +18,7 @@ package org.springframework.data.solr.core.mapping;
 import java.util.Collection;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentProperty;
 
 /**
@@ -101,6 +102,18 @@ public interface SolrPersistentProperty extends PersistentProperty<SolrPersisten
 	 * @since 1.3
 	 */
 	boolean isRequired();
+
+	/**
+	 * Returns whether the property is a <em>potential</em> score property of the owning {@link PersistentEntity}. This
+	 * method is mainly used by {@link PersistentEntity} implementation to discover score property candidates on
+	 * {@link PersistentEntity} creation you should rather call
+	 * {@link PersistentEntity#isScoreProperty(PersistentProperty)} to determine whether the current property is the score
+	 * property of that {@link PersistentEntity} under consideration.
+	 * 
+	 * @return
+	 * @since 1.4
+	 */
+	boolean isScoreProperty();
 
 	public enum PropertyToFieldNameConverter implements Converter<SolrPersistentProperty, String> {
 

--- a/src/main/java/org/springframework/data/solr/repository/Score.java
+++ b/src/main/java/org/springframework/data/solr/repository/Score.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.repository;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.data.annotation.ReadOnlyProperty;
+
+/**
+ * Defines the annotated field to store the score of a document within search result.
+ * 
+ * @author Christoph Strobl
+ * @author Francisco Spaeth
+ * @since 1.4
+ */
+@ReadOnlyProperty
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Score {
+
+}

--- a/src/test/java/org/springframework/data/solr/core/SolrTemplateTests.java
+++ b/src/test/java/org/springframework/data/solr/core/SolrTemplateTests.java
@@ -66,6 +66,7 @@ import org.springframework.data.solr.core.query.SimpleStringCriteria;
 import org.springframework.data.solr.core.query.SolrDataQuery;
 import org.springframework.data.solr.core.schema.SolrPersistentEntitySchemaCreator.Feature;
 import org.springframework.data.solr.core.schema.SolrSchemaRequest;
+import org.springframework.data.solr.repository.Score;
 import org.springframework.data.solr.server.SolrServerFactory;
 
 /**
@@ -465,10 +466,31 @@ public class SolrTemplateTests {
 		Assert.assertEquals("/get", captor.getValue().getPath());
 	}
 
+	/**
+	 * @see DATASOLR-160
+	 */
+	@Test
+	public void testSaveShouldNotSaveScoreField() throws IOException, SolrServerException, SecurityException,
+			NoSuchFieldException {
+
+		solrTemplate.saveBean(new DocumentWithScoreAnnotation());
+
+		ArgumentCaptor<SolrInputDocument> captor = ArgumentCaptor.forClass(SolrInputDocument.class);
+		Mockito.verify(solrServerMock, Mockito.times(1)).add(captor.capture(), Mockito.eq(-1));
+
+		Assert.assertNull(captor.getValue().getFieldValue("score"));
+	}
+
 	static class DocumentWithIndexAnnotations {
 
 		@Id String id;
 		@Indexed(name = "namedProperty") String renamedProperty;
+	}
+
+	static class DocumentWithScoreAnnotation {
+
+		@Id String id;
+		@Score Float scoreProperty;
 	}
 
 }

--- a/src/test/java/org/springframework/data/solr/core/SolrTemplateTests.java
+++ b/src/test/java/org/springframework/data/solr/core/SolrTemplateTests.java
@@ -348,7 +348,7 @@ public class SolrTemplateTests {
 		};
 
 		solrTemplate.registerQueryParser(SimpleQuery.class, parser);
-		solrTemplate.query(new SimpleQuery(new SimpleStringCriteria("my:criteria")));
+		solrTemplate.query(new SimpleQuery(new SimpleStringCriteria("my:criteria")), null);
 
 		ArgumentCaptor<SolrParams> captor = ArgumentCaptor.forClass(SolrParams.class);
 

--- a/src/test/java/org/springframework/data/solr/core/mapping/SimpleSolrPersistentEntityTests.java
+++ b/src/test/java/org/springframework/data/solr/core/mapping/SimpleSolrPersistentEntityTests.java
@@ -23,10 +23,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.solr.core.mapping.SimpleSolrPersistentPropertyTest.BeanWithScore;
 import org.springframework.data.util.TypeInformation;
 
 /**
  * @author Christoph Strobl
+ * @author Francisco Spaeth
  */
 @RunWith(MockitoJUnitRunner.class)
 public class SimpleSolrPersistentEntityTests {
@@ -34,6 +36,8 @@ public class SimpleSolrPersistentEntityTests {
 	private static final String CORE_NAME = "core1";
 
 	@SuppressWarnings("rawtypes") @Mock TypeInformation typeInfo;
+
+	@Mock private SolrPersistentProperty property;
 
 	@SuppressWarnings("unchecked")
 	@Test
@@ -107,6 +111,27 @@ public class SimpleSolrPersistentEntityTests {
 		Assert.assertThat(pe.getBoost(), IsNull.nullValue());
 	}
 
+	/**
+	 * @see DATASOLR-210
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testPersistentEntityWithScoreProperty() {
+
+		Mockito.when(typeInfo.getType()).thenReturn(BeanWithScore.class);
+		Mockito.when(property.isScoreProperty()).thenReturn(true);
+		Mockito.when(property.getFieldName()).thenReturn("myScoreProperty");
+
+		SimpleSolrPersistentEntity<BeanWithScore> pe = new SimpleSolrPersistentEntity<BeanWithScore>(typeInfo);
+		pe.addPersistentProperty(property);
+
+		Assert.assertTrue(pe.hasScoreProperty());
+		Assert.assertEquals(property, pe.getScoreProperty());
+		Assert.assertTrue(pe.isScoreProperty(property));
+		Assert.assertEquals("myScoreProperty", pe.getScoreProperty().getFieldName());
+
+	}
+
 	@SolrDocument(solrCoreName = CORE_NAME)
 	static class SearchableBeanWithSolrDocumentAnnotation {}
 
@@ -122,5 +147,7 @@ public class SimpleSolrPersistentEntityTests {
 
 	@SolrDocument(boost = 100)
 	static class DocumentWithBoost {}
+
+	static class DocumentWithScore {}
 
 }

--- a/src/test/java/org/springframework/data/solr/core/mapping/SimpleSolrPersistentPropertyTest.java
+++ b/src/test/java/org/springframework/data/solr/core/mapping/SimpleSolrPersistentPropertyTest.java
@@ -45,7 +45,7 @@ public class SimpleSolrPersistentPropertyTest {
 	 */
 	@Test
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public void testScoredProperty() throws NoSuchFieldException, SecurityException, IntrospectionException {
+	public void scoredPropertyShouldBeReadOnlyAndNotWritable() throws NoSuchFieldException, SecurityException, IntrospectionException {
 
 		Field field = BeanWithScore.class.getDeclaredField("myScoreProperty");
 		PropertyDescriptor propertyDescriptor = new PropertyDescriptor("myScoreProperty", BeanWithScore.class,
@@ -58,8 +58,8 @@ public class SimpleSolrPersistentPropertyTest {
 		SimpleSolrPersistentProperty property = new SimpleSolrPersistentProperty(field, propertyDescriptor, owner,
 				simpleTypeHolder);
 
-		Assert.assertTrue(property.isReadonly());
 		Assert.assertTrue(property.isScoreProperty());
+		Assert.assertFalse(property.isWritable());
 
 	}
 

--- a/src/test/java/org/springframework/data/solr/core/mapping/SimpleSolrPersistentPropertyTest.java
+++ b/src/test/java/org/springframework/data/solr/core/mapping/SimpleSolrPersistentPropertyTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.mapping;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Field;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.model.SimpleTypeHolder;
+import org.springframework.data.solr.repository.Score;
+import org.springframework.data.util.TypeInformation;
+
+/**
+ * @author Francisco Spaeth
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleSolrPersistentPropertyTest {
+
+	@Mock private PersistentEntity<BeanWithScore, SolrPersistentProperty> owner;
+	@Mock private SimpleTypeHolder simpleTypeHolder;
+	@Mock private TypeInformation<BeanWithScore> typeInformation;
+
+	/**
+	 * @see DATASOLR-210
+	 */
+	@Test
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void testScoredProperty() throws NoSuchFieldException, SecurityException, IntrospectionException {
+
+		Field field = BeanWithScore.class.getDeclaredField("myScoreProperty");
+		PropertyDescriptor propertyDescriptor = new PropertyDescriptor("myScoreProperty", BeanWithScore.class,
+				"getMyScoreProperty", null);
+
+		Mockito.when(owner.getType()).thenReturn((Class) BeanWithScore.class);
+		Mockito.when(owner.getTypeInformation()).thenReturn(typeInformation);
+		Mockito.when(typeInformation.getProperty("myScoreProperty")).thenReturn((TypeInformation) typeInformation);
+
+		SimpleSolrPersistentProperty property = new SimpleSolrPersistentProperty(field, propertyDescriptor, owner,
+				simpleTypeHolder);
+
+		Assert.assertTrue(property.isReadonly());
+		Assert.assertTrue(property.isScoreProperty());
+
+	}
+
+	class BeanWithScore {
+
+		@Score private Float myScoreProperty;
+
+		public Float getMyScoreProperty() {
+			return myScoreProperty;
+		}
+
+	}
+
+}

--- a/src/test/java/org/springframework/data/solr/core/schema/SolrSchmeaResolverUnitTests.java
+++ b/src/test/java/org/springframework/data/solr/core/schema/SolrSchmeaResolverUnitTests.java
@@ -15,11 +15,11 @@
  */
 package org.springframework.data.solr.core.schema;
 
-import static org.hamcrest.beans.HasPropertyWithValue.*;
-import static org.hamcrest.core.AllOf.*;
-import static org.hamcrest.core.IsEqual.*;
-import static org.hamcrest.core.IsNull.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,6 +35,7 @@ import org.springframework.data.solr.core.mapping.SimpleSolrPersistentEntity;
 import org.springframework.data.solr.core.mapping.SolrPersistentEntity;
 import org.springframework.data.solr.core.mapping.SolrPersistentProperty;
 import org.springframework.data.solr.core.schema.SchemaDefinition.FieldDefinition;
+import org.springframework.data.solr.repository.Score;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -203,6 +204,17 @@ public class SolrSchmeaResolverUnitTests {
 		ObjectMapper mapper = new ObjectMapper();
 		System.out.println(mapper.writeValueAsString(fieldDef));
 	}
+	
+	/**
+	 * @see DATASOLR-210
+	 */
+	@Test
+	public void scorePropertyShouldNotBeMapped() {
+
+		FieldDefinition fieldDef = schemaResolver.createFieldDefinitionForProperty(getPropertyFor("scoreProperty",
+				Foo.class));
+		assertThat(fieldDef, nullValue());
+	}
 
 	SolrPersistentEntity<?> createEntity(Class<?> type) {
 		return context.getPersistentEntity(type);
@@ -228,6 +240,8 @@ public class SolrSchmeaResolverUnitTests {
 		@Indexed(stored = false) String nonStoredProperty;
 		@Indexed(copyTo = { "foo", "bar" }) String propertyCopiedTo2Fields;
 		@Indexed List<String> collectionProperty;
+		@Score Float scoreProperty;
+
 	}
 
 }


### PR DESCRIPTION
Introduced @Score annotation;
Added @Score meta-data access methods on SolrPersistentEntity and SolrPersistentProperty;
Handled score field on SolrResponse on MappingSolrConverter;
Added @Score documentation;