### PR TITLE
DATASOLR-236 - face.limit parameter may be set to negative value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-solr</artifactId>
-	<version>1.5.0.BUILD-SNAPSHOT</version>
+	<version>1.5.0.DATASOLR-236-SNAPSHOT</version>
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>

--- a/src/main/java/org/springframework/data/solr/core/DefaultQueryParser.java
+++ b/src/main/java/org/springframework/data/solr/core/DefaultQueryParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2014 the original author or authors.
+ * Copyright 2012 - 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -294,7 +294,8 @@ public class DefaultQueryParser extends QueryParserBase<SolrDataQuery> {
 		solrQuery.setFacetMinCount(facetOptions.getFacetMinCount());
 		solrQuery.setFacetLimit(facetOptions.getPageable().getPageSize());
 		if (facetOptions.getPageable().getPageNumber() > 0) {
-			solrQuery.set(FacetParams.FACET_OFFSET, facetOptions.getPageable().getOffset());
+			int offset = Math.max(0, facetOptions.getPageable().getOffset());
+			solrQuery.set(FacetParams.FACET_OFFSET, offset);
 		}
 		if (FacetOptions.FacetSort.INDEX.equals(facetOptions.getFacetSort())) {
 			solrQuery.setFacetSort(FacetParams.FACET_SORT_INDEX);
@@ -304,9 +305,6 @@ public class DefaultQueryParser extends QueryParserBase<SolrDataQuery> {
 
 	private void appendFacetingOnFields(SolrQuery solrQuery, FacetQuery query) {
 		FacetOptions facetOptions = query.getFacetOptions();
-		if (facetOptions.getPageable().getPageNumber() > 0) {
-			solrQuery.set(FacetParams.FACET_OFFSET, facetOptions.getPageable().getOffset());
-		}
 		solrQuery.addFacetField(convertFieldListToStringArray(facetOptions.getFacetOnFields()));
 		if (facetOptions.hasFacetPrefix()) {
 			solrQuery.setFacetPrefix(facetOptions.getFacetPrefix());

--- a/src/main/java/org/springframework/data/solr/core/query/FacetOptions.java
+++ b/src/main/java/org/springframework/data/solr/core/query/FacetOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2013 the original author or authors.
+ * Copyright 2012 - 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -208,7 +208,7 @@ public class FacetOptions {
 	 * @return
 	 */
 	public FacetOptions setFacetLimit(int rowsToReturn) {
-		this.facetLimit = Math.max(1, rowsToReturn);
+		this.facetLimit = rowsToReturn;
 		return this;
 	}
 

--- a/src/test/java/org/springframework/data/solr/core/DefaultQueryParserTests.java
+++ b/src/test/java/org/springframework/data/solr/core/DefaultQueryParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2014 the original author or authors.
+ * Copyright 2012 - 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1374,6 +1374,54 @@ public class DefaultQueryParserTests {
 		Criteria criteria = part2.connect().and(part1).notOperator();
 
 		Assert.assertEquals("-(-(x:foo OR y:bar) AND z:roo)", queryParser.createQueryStringFromNode(criteria));
+	}
+
+	/**
+	 * @see DATASOLR-236
+	 */
+	@Test
+	public void testNegativeFacetLimitUsingFacetOptions_setFacetLimit() {
+		FacetQuery query = new SimpleFacetQuery(new Criteria("field_1").is("value_1"));
+		FacetOptions facetOptions = new FacetOptions(new SimpleField("facet_1"));
+		facetOptions.setFacetLimit(-1);
+		query.setFacetOptions(facetOptions);
+
+		SolrQuery solrQuery = queryParser.constructSolrQuery(query);
+
+		Assert.assertEquals(-1, solrQuery.getFacetLimit());
+		Assert.assertEquals(null, solrQuery.get(FacetParams.FACET_OFFSET));
+	}
+
+	/**
+	 * @see DATASOLR-236
+	 */
+	@Test
+	public void testNegativeFacetLimitUsingFacetOptions_setPageable() {
+		FacetQuery query = new SimpleFacetQuery(new Criteria("field_1").is("value_1"));
+		FacetOptions facetOptions = new FacetOptions(new SimpleField("facet_1"));
+		facetOptions.setPageable(new SolrPageRequest(0, -1));
+		query.setFacetOptions(facetOptions);
+
+		SolrQuery solrQuery = queryParser.constructSolrQuery(query);
+
+		Assert.assertEquals(-1, solrQuery.getFacetLimit());
+		Assert.assertEquals(null, solrQuery.get(FacetParams.FACET_OFFSET));
+	}
+
+	/**
+	 * @see DATASOLR-236
+	 */
+	@Test
+	public void testNegativeFacetOffsetAndFacetLimitUsingFacetOptions_setPageable() {
+		FacetQuery query = new SimpleFacetQuery(new Criteria("field_1").is("value_1"));
+		FacetOptions facetOptions = new FacetOptions(new SimpleField("facet_1"));
+		facetOptions.setPageable(new SolrPageRequest(1, -1));
+		query.setFacetOptions(facetOptions);
+
+		SolrQuery solrQuery = queryParser.constructSolrQuery(query);
+
+		Assert.assertEquals(-1, solrQuery.getFacetLimit());
+		Assert.assertEquals(Integer.valueOf(0), solrQuery.getInt(FacetParams.FACET_OFFSET));
 	}
 
 	private void assertPivotFactingPresent(SolrQuery solrQuery, String... expected) {

--- a/src/test/java/org/springframework/data/solr/core/query/FacetOptionsTests.java
+++ b/src/test/java/org/springframework/data/solr/core/query/FacetOptionsTests.java
@@ -195,7 +195,7 @@ public class FacetOptionsTests {
 		Assert.assertEquals(20, options.getFacetLimit());
 
 		options.setFacetLimit(-1);
-		Assert.assertEquals(1, options.getFacetLimit());
+		Assert.assertEquals(-1, options.getFacetLimit());
 	}
 
 	@Test


### PR DESCRIPTION
Removed duplicated code setting facet.offset;
Removed Math.max(1, rowsToReturn) constraint on FacetOptions.setFacetLimit;
Added Math.max(0, offset) when setting FacetParams.FACET_OFFSET on DefaultQueryParser;
Modified test of FacetOptionsTest to test negative facet limits set;
Added tests to DefaultQueryParsetTest to ensure facet limit is being set as expected whenever negative values are used as facet limit;