### PR TITLE
DATASOLR-202 - Auto prefix/suffix map values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-solr</artifactId>
-	<version>1.5.0.BUILD-SNAPSHOT</version>
+	<version>1.5.0.DATASOLR-202-SNAPSHOT</version>
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>

--- a/src/main/asciidoc/reference/data-solr.adoc
+++ b/src/main/asciidoc/reference/data-solr.adoc
@@ -429,6 +429,10 @@ public class Product {
   @Field("mappedField_*")
   private Map<String, List<String>> mappedFieldValues; 
   
+  @Dynamic
+  @Field("dynamicMappedField_*")
+  private Map<String, String> dynamicMappedFieldValues; 
+  
   @Field
   private GeoLocation location;
 				
@@ -454,7 +458,10 @@ Taking a look as the above `MappingSolrConverter` will do as follows:
 | `//not written to document`
 
 | mappedFieldValues
-| `<field name="mapentry[0].key">mapentry[0].value[0]</field>` `<field name="mapentry[0].key">mapentry[0].value[2]</field>` `<field name="mapentry[1].key">mapentry[1].value[0]</field>`
+| `<field name="mapentry[0].key">mapentry[0].value[0]</field>` `<field name="mapentry[0].key">mapentry[0].value[1]</field>` `<field name="mapentry[1].key">mapentry[1].value[0]</field>`
+
+| dynamicMappedFieldValues
+| `<field name="'dynamicMappedField_' + mapentry[0].key">mapentry[0].value[0]</field>` `<field name="'dynamicMappedField_' + mapentry[0].key">mapentry[0].value[1]</field>` `<field name="'dynamicMappedField_' + mapentry[1].key">mapentry[1].value[0]</field>`
 
 | location
 | `<field name="location">48.362893,14.534437</field>`

--- a/src/main/java/org/springframework/data/solr/core/mapping/Dynamic.java
+++ b/src/main/java/org/springframework/data/solr/core/mapping/Dynamic.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2012 - 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.mapping;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Map;
+
+/**
+ * Declare a field as dynamic.
+ * <p>
+ * Used mainly to annotate {@link Map} fields, indicates the field should have its key parsed whenever reading the
+ * document from Solr and formatted whenever being written to Solr based on wildcard field name defined for it.
+ * <p>
+ * Example:
+ * <p>
+ * Definition:
+ * 
+ * <pre class="code">
+ * class MyBeanClass {
+ * 
+ * 	&#064;Id private String id;
+ * 	&#064;Dynamic @Field(&quot;*_s&quot;) private Map&lt;String, String&gt; values;
+ * 
+ * 	// setters and getters
+ * 
+ * }
+ * </pre>
+ * <p>
+ * Use:
+ * 
+ * <pre class="code">
+ * Map&lt;String, String&gt; values = new HashMap&lt;&gt;();
+ * values.put(&quot;v1&quot;, &quot;value for key v1&quot;);
+ * values.put(&quot;v2&quot;, &quot;value for key v2&quot;);
+ * 
+ * MyBeanClass bean = new MyBeanClass();
+ * bean.setId("id-bean-1");
+ * bean.setValues(values);
+ * 
+ * solrTemplate.saveBean(bean);
+ * solrTemplate.commit();
+ * 
+ * ...
+ * 
+ * MyBeanClass bean = solrTemplate.getById(&quot;id-bean-1&quot;, MyBeanClass.class);
+ * bean.getValues().get(&quot;v1&quot;);
+ * </pre>
+ * 
+ * The result on Solr side will be a document with the foolowing structure:
+ * 
+ * <pre class="code">
+ * {
+ *   &quot;id&quot;: &quot;id-bean-1&quot;,
+ *   &quot;v1_s&quot;: &quot;value for key v1&quot;,
+ *   &quot;v2_s&quot;: &quot;value for key v2&quot;,
+ * }
+ * </pre>
+ * 
+ * @author Francisco Spaeth
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD })
+public @interface Dynamic {
+}

--- a/src/main/java/org/springframework/data/solr/core/mapping/SimpleSolrPersistentProperty.java
+++ b/src/main/java/org/springframework/data/solr/core/mapping/SimpleSolrPersistentProperty.java
@@ -285,4 +285,12 @@ public class SimpleSolrPersistentProperty extends AnnotationBasedPersistentPrope
 		return findAnnotation(Score.class) != null;
 	}
 
+	/* (non-Javadoc)
+	 * @see org.springframework.data.solr.core.mapping.SolrPersistentProperty#isDynamicProperty()
+	 */
+	@Override
+	public boolean isDynamicProperty() {
+		return findAnnotation(Dynamic.class) != null;
+	}
+
 }

--- a/src/main/java/org/springframework/data/solr/core/mapping/SolrPersistentProperty.java
+++ b/src/main/java/org/springframework/data/solr/core/mapping/SolrPersistentProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2014 the original author or authors.
+ * Copyright 2012 - 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,15 @@ public interface SolrPersistentProperty extends PersistentProperty<SolrPersisten
 	 * @since 1.4
 	 */
 	boolean isScoreProperty();
+
+	/**
+	 * Returns whether the property should be handled as dynamic property.
+	 * 
+	 * @return
+	 * @see {@link org.springframework.data.solr.core.mapping.Dynamic}
+	 * @since 1.5
+	 */
+	boolean isDynamicProperty();
 
 	public enum PropertyToFieldNameConverter implements Converter<SolrPersistentProperty, String> {
 


### PR DESCRIPTION
We introduced @Dynamic annotation to allow the use of maps decoupled from its field name definition.

Therefore we:
 - Introduced @Dynamic annotation;
 - Adapted MappingSolrConverter to derivate name from field name definition when annotated with @Dynamic;
 - Added @Dynamic support method 'isDynamicProperty' to SolrPersistentProperty;