### PR TITLE
    DATASOLR-274 when query expression too long,cause HttpException.

### DIFF
--- a/src/main/java/org/springframework/data/solr/core/SolrTemplate.java
+++ b/src/main/java/org/springframework/data/solr/core/SolrTemplate.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.SolrPingResponse;
@@ -414,7 +415,7 @@ public class SolrTemplate implements SolrOperations, InitializingBean, Applicati
 		return execute(new SolrCallback<QueryResponse>() {
 			@Override
 			public QueryResponse doInSolr(SolrClient solrClient) throws SolrServerException, IOException {
-				return solrClient.query(solrQuery);
+				return solrClient.query(solrQuery,SolrRequest.METHOD.POST);
 			}
 		});
 	}


### PR DESCRIPTION
when query expression too long, it cause HttpException, i think spring-data-solr should using post rather than get in SolrTemplate