### PR TITLE
DATASOLR-296 1.5.x @Query problem with more of 10 params

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-solr</artifactId>
-	<version>1.5.4.BUILD-SNAPSHOT</version>
+	<version>1.5.4.RELEASE</version>
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.7.4.RELEASE</version>
+		<version>1.7.5.BUILD-SNAPSHOT</version>
 		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
 	</parent>
 
@@ -24,7 +24,7 @@
 		<commons.lang>3.1</commons.lang>
 		<httpcomponents>4.2.2</httpcomponents>
 		<solr>4.10.4</solr>
-		<springdata.commons>1.11.4.RELEASE</springdata.commons>
+		<springdata.commons>1.11.5.BUILD-SNAPSHOT</springdata.commons>
 	</properties>
 
 	<developers>
@@ -290,8 +290,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-release</id>
-			<url>https://repo.spring.io/libs-release</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.7.0.RELEASE</version>
+		<version>1.7.1.BUILD-SNAPSHOT</version>
 		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
 	</parent>
 
@@ -24,7 +24,7 @@
 		<commons.lang>3.1</commons.lang>
 		<httpcomponents>4.2.2</httpcomponents>
 		<solr>4.10.4</solr>
-		<springdata.commons>1.11.0.RELEASE</springdata.commons>
+		<springdata.commons>1.11.1.BUILD-SNAPSHOT</springdata.commons>
 	</properties>
 
 	<developers>
@@ -290,8 +290,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-release</id>
-			<url>https://repo.spring.io/libs-release</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-solr</artifactId>
-	<version>1.5.1.BUILD-SNAPSHOT</version>
+	<version>1.5.1.RELEASE</version>
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.7.2.BUILD-SNAPSHOT</version>
+		<version>1.7.2.RELEASE</version>
 		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
 	</parent>
 
@@ -24,7 +24,7 @@
 		<commons.lang>3.1</commons.lang>
 		<httpcomponents>4.2.2</httpcomponents>
 		<solr>4.10.4</solr>
-		<springdata.commons>1.11.2.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.11.2.RELEASE</springdata.commons>
 	</properties>
 
 	<developers>
@@ -290,8 +290,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<id>spring-libs-release</id>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.7.4.BUILD-SNAPSHOT</version>
+		<version>1.7.4.RELEASE</version>
 		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
 	</parent>
 
@@ -24,7 +24,7 @@
 		<commons.lang>3.1</commons.lang>
 		<httpcomponents>4.2.2</httpcomponents>
 		<solr>4.10.4</solr>
-		<springdata.commons>1.11.4.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.11.4.RELEASE</springdata.commons>
 	</properties>
 
 	<developers>
@@ -290,8 +290,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<id>spring-libs-release</id>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.7.1.RELEASE</version>
+		<version>1.7.2.BUILD-SNAPSHOT</version>
 		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
 	</parent>
 
@@ -24,7 +24,7 @@
 		<commons.lang>3.1</commons.lang>
 		<httpcomponents>4.2.2</httpcomponents>
 		<solr>4.10.4</solr>
-		<springdata.commons>1.11.1.RELEASE</springdata.commons>
+		<springdata.commons>1.11.2.BUILD-SNAPSHOT</springdata.commons>
 	</properties>
 
 	<developers>
@@ -290,8 +290,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-release</id>
-			<url>https://repo.spring.io/libs-release</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-solr</artifactId>
-	<version>1.5.0.RELEASE</version>
+	<version>1.5.1.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.7.1.BUILD-SNAPSHOT</version>
+		<version>1.7.1.RELEASE</version>
 		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
 	</parent>
 
@@ -24,7 +24,7 @@
 		<commons.lang>3.1</commons.lang>
 		<httpcomponents>4.2.2</httpcomponents>
 		<solr>4.10.4</solr>
-		<springdata.commons>1.11.1.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.11.1.RELEASE</springdata.commons>
 	</properties>
 
 	<developers>
@@ -290,8 +290,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-snapshot</id>
-			<url>https://repo.spring.io/libs-snapshot</url>
+			<id>spring-libs-release</id>
+			<url>https://repo.spring.io/libs-release</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.7.2.RELEASE</version>
+		<version>1.7.3.BUILD-SNAPSHOT</version>
 		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
 	</parent>
 
@@ -24,7 +24,7 @@
 		<commons.lang>3.1</commons.lang>
 		<httpcomponents>4.2.2</httpcomponents>
 		<solr>4.10.4</solr>
-		<springdata.commons>1.11.2.RELEASE</springdata.commons>
+		<springdata.commons>1.11.3.BUILD-SNAPSHOT</springdata.commons>
 	</properties>
 
 	<developers>
@@ -290,8 +290,8 @@
 
 	<repositories>
 		<repository>
-			<id>spring-libs-release</id>
-			<url>https://repo.spring.io/libs-release</url>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-solr</artifactId>
-	<version>1.5.1.RELEASE</version>
+	<version>1.5.2.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-solr</artifactId>
-	<version>1.5.4.RELEASE</version>
+	<version>1.5.5.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-solr</artifactId>
-	<version>1.5.3.BUILD-SNAPSHOT</version>
+	<version>1.5.4.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>1.7.3.BUILD-SNAPSHOT</version>
+		<version>1.7.4.BUILD-SNAPSHOT</version>
 		<relativePath>../spring-data-build/parent/pom.xml</relativePath>
 	</parent>
 
@@ -24,7 +24,7 @@
 		<commons.lang>3.1</commons.lang>
 		<httpcomponents>4.2.2</httpcomponents>
 		<solr>4.10.4</solr>
-		<springdata.commons>1.11.3.BUILD-SNAPSHOT</springdata.commons>
+		<springdata.commons>1.11.4.BUILD-SNAPSHOT</springdata.commons>
 	</properties>
 
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-solr</artifactId>
-	<version>1.5.2.RELEASE</version>
+	<version>1.5.3.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-solr</artifactId>
-	<version>1.5.2.BUILD-SNAPSHOT</version>
+	<version>1.5.2.RELEASE</version>
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>

--- a/src/main/java/org/springframework/data/solr/core/ResultHelper.java
+++ b/src/main/java/org/springframework/data/solr/core/ResultHelper.java
@@ -94,8 +94,8 @@ final class ResultHelper {
 		}
 
 		TermsResponse termsResponse = response.getTermsResponse();
-		Map<String, List<TermsFieldEntry>> result = new LinkedHashMap<String, List<TermsFieldEntry>>(termsResponse
-				.getTermMap().size());
+		Map<String, List<TermsFieldEntry>> result = new LinkedHashMap<String, List<TermsFieldEntry>>(
+				termsResponse.getTermMap().size());
 
 		for (Map.Entry<String, List<Term>> entry : termsResponse.getTermMap().entrySet()) {
 			List<TermsFieldEntry> terms = new ArrayList<TermsFieldEntry>(entry.getValue().size());
@@ -119,8 +119,8 @@ final class ResultHelper {
 		}
 		Map<Field, Page<FacetFieldEntry>> facetResult = new HashMap<Field, Page<FacetFieldEntry>>();
 
-		if (CollectionUtils.isNotEmpty(response.getFacetFields())) {
-			int initalPageSize = query.getFacetOptions().getPageable().getPageSize();
+		if (!CollectionUtils.isEmpty(response.getFacetFields())) {
+			int initalPageSize = Math.max(1, query.getFacetOptions().getPageable().getPageSize());
 			for (FacetField facetField : response.getFacetFields()) {
 				if (facetField != null && StringUtils.hasText(facetField.getName())) {
 					Field field = new SimpleField(facetField.getName());
@@ -131,11 +131,11 @@ final class ResultHelper {
 								pageEntries.add(new SimpleFacetFieldEntry(field, count.getName(), count.getCount()));
 							}
 						}
-						facetResult.put(field, new SolrResultPage<FacetFieldEntry>(pageEntries, query.getFacetOptions()
-								.getPageable(), facetField.getValueCount(), null));
+						facetResult.put(field, new SolrResultPage<FacetFieldEntry>(pageEntries,
+								query.getFacetOptions().getPageable(), facetField.getValueCount(), null));
 					} else {
-						facetResult.put(field, new SolrResultPage<FacetFieldEntry>(Collections.<FacetFieldEntry> emptyList(), query
-								.getFacetOptions().getPageable(), 0, null));
+						facetResult.put(field, new SolrResultPage<FacetFieldEntry>(Collections.<FacetFieldEntry> emptyList(),
+								query.getFacetOptions().getPageable(), 0, null));
 					}
 				}
 			}

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,16 @@
 Spring Data Solr Changelog
 ==========================
 
+Changes in version 2.0.0.M1 (2016-02-12)
+----------------------------------------
+* DATASOLR-275 - Add code of conduct.
+* DATASOLR-273 - Release 2.0 M1 (Hopper).
+* DATASOLR-271 - Adapt to API changes in Spring Data Commons.
+* DATASOLR-265 - Upgrade to Solr 5.3.1.
+* DATASOLR-232 - Upgrade to Solr 5.
+* DATASOLR-228 - Support for Solr 5.
+
+
 Changes in version 1.5.2.RELEASE (2015-12-18)
 ---------------------------------------------
 * DATASOLR-272 - Release 1.5.2 (Gosling).

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,11 @@
 Spring Data Solr Changelog
 ==========================
 
+Changes in version 1.5.2.RELEASE (2015-12-18)
+---------------------------------------------
+* DATASOLR-272 - Release 1.5.2 (Gosling).
+
+
 Changes in version 1.5.1.RELEASE (2015-11-15)
 ---------------------------------------------
 * DATASOLR-267 - Release 1.5.1 (Gosling).

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,11 @@
 Spring Data Solr Changelog
 ==========================
 
+Changes in version 1.5.1.RELEASE (2015-11-15)
+---------------------------------------------
+* DATASOLR-267 - Release 1.5.1 (Gosling).
+
+
 Changes in version 1.3.4.RELEASE (2015-10-14)
 ---------------------------------------------
 * DATASOLR-263 - Release 1.3.4 (Evans).

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,11 @@
 Spring Data Solr Changelog
 ==========================
 
+Changes in version 1.5.4.RELEASE (2016-02-23)
+---------------------------------------------
+* DATASOLR-278 - Release 1.5.4 (Gosling SR4).
+
+
 Changes in version 2.0.0.M1 (2016-02-12)
 ----------------------------------------
 * DATASOLR-275 - Add code of conduct.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,13 @@
 Spring Data Solr Changelog
 ==========================
 
+Changes in version 2.0.0.RC1 (2016-03-18)
+-----------------------------------------
+* DATASOLR-285 - Release 2.0 RC1 (Hopper).
+* DATASOLR-280 - Order of Facet fields are not maintained.
+* DATASOLR-176 - Add fromIndex to Join.
+
+
 Changes in version 1.5.4.RELEASE (2016-02-23)
 ---------------------------------------------
 * DATASOLR-278 - Release 1.5.4 (Gosling SR4).

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,11 @@
 Spring Data Solr Changelog
 ==========================
 
+Changes in version 1.3.4.RELEASE (2015-10-14)
+---------------------------------------------
+* DATASOLR-263 - Release 1.3.4 (Evans).
+
+
 Changes in version 1.5.0.RELEASE (2015-09-01)
 ---------------------------------------------
 * DATASOLR-257 - Release 1.5 GA (Gosling).

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Solr 1.5.1
+Spring Data Solr 1.5.2
 Copyright (c) [2013-2015] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Solr 1.5 GA
+Spring Data Solr 1.5.1
 Copyright (c) [2013-2015] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Solr 1.5.2
+Spring Data Solr 1.5.4
 Copyright (c) [2013-2015] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").

--- a/src/test/java/org/springframework/data/solr/core/ResultHelperTests.java
+++ b/src/test/java/org/springframework/data/solr/core/ResultHelperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2015 the original author or authors.
+ * Copyright 2012 - 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -773,6 +773,26 @@ public class ResultHelperTests {
 		Assert.assertEquals("count1", content.get(0).getValue());
 		Assert.assertEquals(2, content.get(1).getValueCount());
 		Assert.assertEquals("count2", content.get(1).getValue());
+	}
+
+	/**
+	 * @see DATASOLR-305
+	 */
+	@Test
+	public void testConvertFacetQueryResponseForNegativeFacetLimit() {
+
+		List<FacetField> fieldList = new ArrayList<FacetField>(1);
+		FacetField ffield = createFacetField("field_1", 1, 2);
+		fieldList.add(ffield);
+
+		Mockito.when(response.getFacetFields()).thenReturn(fieldList);
+
+		FacetQuery query = createFacetQuery("field_1");
+		query.getFacetOptions().setFacetLimit(-1);
+
+		Map<Field, Page<FacetFieldEntry>> result = ResultHelper.convertFacetQueryResponseToFacetPageMap(query, response);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(1, result.size());
 	}
 
 	private NamedList<Object> createFieldStatNameList(Object min, Object max, Double sum, Long count, Long missing,


### PR DESCRIPTION
Hello,
I have a @Query with over 10 params, the problem is that when Spring is doing param replacement, the "?10" param is not equals to the 10'th parameter of the fonction.

`
public interface ShopRepository extends SolrCrudRepository<Shop, String> {
   @Query("location: [?0,?1 TO ?2,?3] AND country_id: ?4 AND region_id: ?5 AND city_id: ?6 AND   district_id: ?7 AND dealer_id: ?8 AND NOT tags: *?9* AND brand: *?10* AND lang_code: ?11")
    ArrayList<Shop> findByBoundingBox(Double southWestLat, Double southWesLng, Double northEastLat, Double northEastLng, String countryId, String regionId, String cityId, String districtId, String dealerId, String tags, String brand, String langCode );
}
`