### PR TITLE
DATASOLR-310 - Limit Parameter on GroupOptions is not included in Query when -1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-solr</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATASOLR-310-SNAPSHOT</version>
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>

--- a/src/main/java/org/springframework/data/solr/core/DefaultQueryParser.java
+++ b/src/main/java/org/springframework/data/solr/core/DefaultQueryParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2015 the original author or authors.
+ * Copyright 2012 - 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -216,7 +216,7 @@ public class DefaultQueryParser extends QueryParserBase<SolrDataQuery> {
 			solrQuery.add(GroupParams.GROUP_CACHE_PERCENTAGE, String.valueOf(groupOptions.getCachePercent()));
 		}
 
-		if (groupOptions.getLimit() != null && groupOptions.getLimit() >= 0) {
+		if (groupOptions.getLimit() != null) {
 			solrQuery.set(GroupParams.GROUP_LIMIT, groupOptions.getLimit());
 		}
 

--- a/src/test/java/org/springframework/data/solr/core/DefaultQueryParserTests.java
+++ b/src/test/java/org/springframework/data/solr/core/DefaultQueryParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 - 2015 the original author or authors.
+ * Copyright 2012 - 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1228,6 +1228,28 @@ public class DefaultQueryParserTests {
 		Assert.assertEquals("field_3 desc", solrQuery.get(GroupParams.GROUP_SORT));
 		Assert.assertEquals("1", solrQuery.get(GroupParams.GROUP_OFFSET));
 		Assert.assertEquals("2", solrQuery.get(GroupParams.GROUP_LIMIT));
+	}
+
+	/**
+	 * @see DATASOLR-310
+	 */
+	@Test
+	public void testConstructGroupQueryWithLimitSetToNegative1() {
+		GroupOptions groupOptions = new GroupOptions();
+
+		SimpleQuery query = new SimpleQuery();
+		query.addCriteria(new SimpleStringCriteria("*:*"));
+		query.setGroupOptions(groupOptions);
+		groupOptions.setLimit(-1);
+		groupOptions.addGroupByField("field_1");
+		groupOptions.addSort(new Sort(Sort.Direction.DESC, "field_3"));
+		groupOptions.setTotalCount(true);
+
+		SolrQuery solrQuery = queryParser.constructSolrQuery(query);
+
+		assertGroupFormatPresent(solrQuery, true);
+		Assert.assertEquals("field_1", solrQuery.get(GroupParams.GROUP_FIELD));
+		Assert.assertEquals("-1", solrQuery.get(GroupParams.GROUP_LIMIT));
 	}
 
 	/**


### PR DESCRIPTION
Removed condition that prevented setting negative values to SolrQuery - GroupParams.GROUP_LIMIT parameter.