### PR TITLE
DATASOLR-276 - Use Set to store qualifiers in CDI extension.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-solr</artifactId>
-	<version>2.1.0.BUILD-SNAPSHOT</version>
+	<version>2.1.0.DATASOLR-276-SNAPSHOT</version>
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>

--- a/src/main/java/org/springframework/data/solr/repository/cdi/SolrRepositoryExtension.java
+++ b/src/main/java/org/springframework/data/solr/repository/cdi/SolrRepositoryExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,14 +38,14 @@ import org.springframework.data.solr.core.SolrOperations;
  */
 public class SolrRepositoryExtension extends CdiRepositoryExtensionSupport {
 
-	private final Map<String, Bean<SolrOperations>> solrOperationsMap = new HashMap<String, Bean<SolrOperations>>();
+	private final Map<Set<Annotation>, Bean<SolrOperations>> solrOperationsMap = new HashMap<Set<Annotation>, Bean<SolrOperations>>();
 
 	@SuppressWarnings("unchecked")
 	<T> void processBean(@Observes ProcessBean<T> processBean) {
 		Bean<T> bean = processBean.getBean();
 		for (Type type : bean.getTypes()) {
 			if (type instanceof Class<?> && SolrOperations.class.isAssignableFrom((Class<?>) type)) {
-				solrOperationsMap.put(bean.getQualifiers().toString(), ((Bean<SolrOperations>) bean));
+				solrOperationsMap.put(bean.getQualifiers(), ((Bean<SolrOperations>) bean));
 			}
 		}
 	}
@@ -62,7 +62,7 @@ public class SolrRepositoryExtension extends CdiRepositoryExtensionSupport {
 	}
 
 	private <T> Bean<T> createRepositoryBean(Class<T> repositoryType, Set<Annotation> qualifiers, BeanManager beanManager) {
-		Bean<SolrOperations> solrOperationBeans = this.solrOperationsMap.get(qualifiers.toString());
+		Bean<SolrOperations> solrOperationBeans = this.solrOperationsMap.get(qualifiers);
 
 		if (solrOperationBeans == null) {
 			throw new UnsatisfiedResolutionException(String.format("Unable to resolve a bean for '%s' with qualifiers %s.",

--- a/src/test/java/org/springframework/data/solr/repository/cdi/CdiRepositoryClient.java
+++ b/src/test/java/org/springframework/data/solr/repository/cdi/CdiRepositoryClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ class CdiRepositoryClient {
 
 	private SamplePersonRepository samplePersonRepository;
 
+	private QualifiedProductRepository qualifiedProductRepository;
+
 	public CdiProductRepository getRepository() {
 		return repository;
 	}
@@ -43,5 +45,14 @@ class CdiRepositoryClient {
 	@Inject
 	public void setSamplePersonRepository(SamplePersonRepository samplePersonRepository) {
 		this.samplePersonRepository = samplePersonRepository;
+	}
+
+	public QualifiedProductRepository getQualifiedProductRepository() {
+		return qualifiedProductRepository;
+	}
+
+	@Inject
+	public void setQualifiedProductRepository(@UserDB @OtherQualifier QualifiedProductRepository qualifiedProductRepository) {
+		this.qualifiedProductRepository = qualifiedProductRepository;
 	}
 }

--- a/src/test/java/org/springframework/data/solr/repository/cdi/ITestCdiRepository.java
+++ b/src/test/java/org/springframework/data/solr/repository/cdi/ITestCdiRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors.
+ * Copyright 2012-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import static org.junit.Assert.*;
 import org.apache.webbeans.cditest.CdiTestContainer;
 import org.apache.webbeans.cditest.CdiTestContainerLoader;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,9 +35,11 @@ public class ITestCdiRepository {
 	private static CdiTestContainer cdiContainer;
 	private CdiProductRepository repository;
 	private SamplePersonRepository samplePersonRepository;
+	private QualifiedProductRepository qualifiedProductRepository;
 
 	@BeforeClass
 	public static void init() throws Exception {
+
 		cdiContainer = CdiTestContainerLoader.getCdiContainer();
 		cdiContainer.startApplicationScope();
 		cdiContainer.bootContainer();
@@ -46,20 +47,24 @@ public class ITestCdiRepository {
 
 	@AfterClass
 	public static void shutdown() throws Exception {
+
 		cdiContainer.stopContexts();
 		cdiContainer.shutdownContainer();
 	}
 
 	@Before
 	public void setUp() {
+
 		CdiRepositoryClient client = cdiContainer.getInstance(CdiRepositoryClient.class);
 		repository = client.getRepository();
 		samplePersonRepository = client.getSamplePersonRepository();
+		qualifiedProductRepository = client.getQualifiedProductRepository();
 	}
 
 	@Test
 	public void testCdiRepository() {
-		Assert.assertNotNull(repository);
+
+		assertNotNull(repository);
 
 		ProductBean bean = new ProductBean();
 		bean.setId("id-1");
@@ -67,22 +72,22 @@ public class ITestCdiRepository {
 
 		repository.save(bean);
 
-		Assert.assertTrue(repository.exists(bean.getId()));
+		assertTrue(repository.exists(bean.getId()));
 
 		ProductBean retrieved = repository.findOne(bean.getId());
-		Assert.assertNotNull(retrieved);
-		Assert.assertEquals(bean.getId(), retrieved.getId());
-		Assert.assertEquals(bean.getName(), retrieved.getName());
+		assertNotNull(retrieved);
+		assertEquals(bean.getId(), retrieved.getId());
+		assertEquals(bean.getName(), retrieved.getName());
 
-		Assert.assertEquals(1, repository.count());
+		assertEquals(1, repository.count());
 
-		Assert.assertTrue(repository.exists(bean.getId()));
+		assertTrue(repository.exists(bean.getId()));
 
 		repository.delete(bean);
 
-		Assert.assertEquals(0, repository.count());
+		assertEquals(0, repository.count());
 		retrieved = repository.findOne(bean.getId());
-		Assert.assertNull(retrieved);
+		assertNull(retrieved);
 	}
 
 	/**
@@ -94,4 +99,20 @@ public class ITestCdiRepository {
 		assertThat(samplePersonRepository.returnOne(), is(1));
 	}
 
+	/**
+	 * @see DATASOLR-276
+	 */
+	@Test
+	public void testQualifiedCdiRepository() {
+
+		ProductBean bean = new ProductBean();
+		bean.setId("id-1");
+		bean.setName("cidContainerTest-1");
+
+		qualifiedProductRepository.save(bean);
+
+		qualifiedProductRepository.delete(bean);
+
+		assertEquals(0, qualifiedProductRepository.count());
+	}
 }

--- a/src/test/java/org/springframework/data/solr/repository/cdi/OtherQualifier.java
+++ b/src/test/java/org/springframework/data/solr/repository/cdi/OtherQualifier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.repository.cdi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * @author Mark Paluch
+ * @see DATASOLR-276
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+@interface OtherQualifier {
+
+}

--- a/src/test/java/org/springframework/data/solr/repository/cdi/QualifiedProductRepository.java
+++ b/src/test/java/org/springframework/data/solr/repository/cdi/QualifiedProductRepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.repository.cdi;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.solr.repository.ProductBean;
+
+/**
+ * @author Mark Paluch
+ * @see DATASOLR-276
+ */
+@OtherQualifier
+@UserDB
+public interface QualifiedProductRepository extends CrudRepository<ProductBean, String> {}

--- a/src/test/java/org/springframework/data/solr/repository/cdi/SolrTemplateProducer.java
+++ b/src/test/java/org/springframework/data/solr/repository/cdi/SolrTemplateProducer.java
@@ -32,6 +32,7 @@ import org.xml.sax.SAXException;
 
 /**
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 @ApplicationScoped
 class SolrTemplateProducer {
@@ -45,6 +46,14 @@ class SolrTemplateProducer {
 		SolrTemplate template = new SolrTemplate(factory);
 		template.afterPropertiesSet();
 		return template;
+	}
+
+	@UserDB
+	@OtherQualifier
+	@Produces
+	@ApplicationScoped
+	public SolrOperations createQualifiedSolrTemplate(SolrOperations solrOperations) {
+		return solrOperations;
 	}
 
 	@PreDestroy
@@ -66,7 +75,5 @@ class SolrTemplateProducer {
 		} catch (SAXException e) {
 			throw new RuntimeException(e);
 		}
-
 	}
-
 }

--- a/src/test/java/org/springframework/data/solr/repository/cdi/UserDB.java
+++ b/src/test/java/org/springframework/data/solr/repository/cdi/UserDB.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.repository.cdi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * @author Mark Paluch
+ * @see DATASOLR-276
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+@interface UserDB {
+
+}


### PR DESCRIPTION
Qualifiers are now stored in their original set instead of using the toString representation.

----

Related ticket: [DATASOLR-276](https://jira.spring.io/browse/DATASOLR-276)