### PR TITLE
DATASOLR-437 Wrapping the Boolean operator terms in quotes

### DIFF
--- a/src/main/java/org/springframework/data/solr/core/QueryParserBase.java
+++ b/src/main/java/org/springframework/data/solr/core/QueryParserBase.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -66,6 +67,7 @@ import org.springframework.util.CollectionUtils;
  * @author Francisco Spaeth
  * @author Radek Mensik
  * @author David Webb
+ * @author Michael Rocke
  */
 public abstract class QueryParserBase<QUERYTPYE extends SolrDataQuery> implements QueryParser {
 
@@ -494,10 +496,13 @@ public abstract class QueryParserBase<QUERYTPYE extends SolrDataQuery> implement
 
 		protected static final String DOUBLEQUOTE = "\"";
 
+		protected final Set<String> BOOLEAN_OPERATORS = Sets.newHashSet("NOT", "AND", "OR");
+
 		protected final String[] RESERVED_CHARS = { DOUBLEQUOTE, "+", "-", "&&", "||", "!", "(", ")", "{", "}", "[", "]",
 				"^", "~", "*", "?", ":", "\\" };
 		protected String[] RESERVED_CHARS_REPLACEMENT = { "\\" + DOUBLEQUOTE, "\\+", "\\-", "\\&\\&", "\\|\\|", "\\!",
 				"\\(", "\\)", "\\{", "\\}", "\\[", "\\]", "\\^", "\\~", "\\*", "\\?", "\\:", "\\\\" };
+
 
 		@Override
 		public Object process(@Nullable Predicate predicate, @Nullable Field field) {
@@ -523,7 +528,7 @@ public abstract class QueryParserBase<QUERYTPYE extends SolrDataQuery> implement
 		}
 
 		private String processWhiteSpaces(String criteriaValue) {
-			if (StringUtils.contains(criteriaValue, CRITERIA_VALUE_SEPERATOR)) {
+			if (StringUtils.contains(criteriaValue, CRITERIA_VALUE_SEPERATOR) || BOOLEAN_OPERATORS.contains(criteriaValue)) {
 				return DOUBLEQUOTE + criteriaValue + DOUBLEQUOTE;
 			}
 			return criteriaValue;

--- a/src/test/java/org/springframework/data/solr/core/DefaultQueryParserTests.java
+++ b/src/test/java/org/springframework/data/solr/core/DefaultQueryParserTests.java
@@ -82,6 +82,7 @@ import org.springframework.data.solr.core.query.StatsOptions;
  * @author Philipp Jardas
  * @author Francisco Spaeth
  * @author Petar Tahchiev
+ * @author Michael Rocke
  */
 public class DefaultQueryParserTests {
 
@@ -204,6 +205,24 @@ public class DefaultQueryParserTests {
 
 		Criteria criteria = new Criteria("field_1").is("with \"quote");
 		assertEquals("field_1:\"with \\\"quote\"", queryParser.createQueryStringFromCriteria(criteria));
+	}
+
+	@Test //DATASOLR-437
+	public void testCriteriaWithANDOperator() {
+		Criteria criteria = new Criteria("field_1").is("AND");
+		assertEquals("field_1:\"AND\"", queryParser.createQueryStringFromCriteria(criteria));
+	}
+
+	@Test //DATASOLR-437
+	public void testCriteriaWithOROperator() {
+		Criteria criteria = new Criteria("field_1").is("OR");
+		assertEquals("field_1:\"OR\"", queryParser.createQueryStringFromCriteria(criteria));
+	}
+
+	@Test //DATASOLR-437
+	public void testCriteriaWithNOTOperator() {
+		Criteria criteria = new Criteria("field_1").is("NOT");
+		assertEquals("field_1:\"NOT\"", queryParser.createQueryStringFromCriteria(criteria));
 	}
 
 	@Test


### PR DESCRIPTION
When a single boolean operator (AND, NOT and OR) is supplied, to treat them as simple text values and not part of the boolean expression