### PR TITLE
URL Cleanup

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>
-	<url>http://github.com/spring-projects/spring-data-solr</url>
+	<url>https://github.com/spring-projects/spring-data-solr</url>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
@@ -288,7 +288,7 @@
 				<repository>
 					<id>apache.snapshots</id>
 					<name>Apache Snapshot Repository</name>
-					<url>http://repository.apache.org/snapshots</url>
+					<url>https://repository.apache.org/snapshots</url>
 					<releases>
 						<enabled>false</enabled>
 					</releases>
@@ -304,7 +304,7 @@
 				<repository>
 					<id>apache.snapshots</id>
 					<name>Apache Snapshot Repository</name>
-					<url>http://repository.apache.org/snapshots</url>
+					<url>https://repository.apache.org/snapshots</url>
 					<releases>
 						<enabled>false</enabled>
 					</releases>
@@ -329,7 +329,7 @@
 
 	<ciManagement>
 		<system>Bamboo</system>
-		<url>http://build.spring.io/browse/DATASOLR</url>
+		<url>https://build.spring.io/browse/DATASOLR</url>
 	</ciManagement>
 
 	<repositories>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://build.spring.io/browse/DATASOLR migrated to:  
  https://build.spring.io/browse/DATASOLR ([https](https://build.spring.io/browse/DATASOLR) result 200).
* http://github.com/spring-projects/spring-data-solr migrated to:  
  https://github.com/spring-projects/spring-data-solr ([https](https://github.com/spring-projects/spring-data-solr) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://repository.apache.org/snapshots migrated to:  
  https://repository.apache.org/snapshots ([https](https://repository.apache.org/snapshots) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance