### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -9,7 +9,7 @@
 
 	<name>Spring Data Solr</name>
 	<description>Spring Data module providing support for Apache Solr repositories.</description>
-	<url>http://github.com/spring-projects/spring-data-solr</url>
+	<url>https://github.com/spring-projects/spring-data-solr</url>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
@@ -272,7 +272,7 @@
 
 	<ciManagement>
 		<system>Bamboo</system>
-		<url>http://build.spring.io/browse/DATASOLR</url>
+		<url>https://build.spring.io/browse/DATASOLR</url>
 	</ciManagement>
 
 	<repositories>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://build.spring.io/browse/DATASOLR with 1 occurrences migrated to:  
  https://build.spring.io/browse/DATASOLR ([https](https://build.spring.io/browse/DATASOLR) result 200).
* http://github.com/spring-projects/spring-data-solr with 1 occurrences migrated to:  
  https://github.com/spring-projects/spring-data-solr ([https](https://github.com/spring-projects/spring-data-solr) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences