### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/src/test/resources/managed-schema/collection1/conf/elevate.xml
+++ b/src/test/resources/managed-schema/collection1/conf/elevate.xml
@@ -20,7 +20,7 @@
      loaded once at startup.  If it is found in Solr's data
      directory, it will be re-loaded every commit.
 
-   See http://wiki.apache.org/solr/QueryElevationComponent for more info
+   See https://wiki.apache.org/solr/QueryElevationComponent for more info
 
 -->
 <elevate>

--- a/src/test/resources/managed-schema/collection1/conf/solrconfig.xml
+++ b/src/test/resources/managed-schema/collection1/conf/solrconfig.xml
@@ -18,7 +18,7 @@
 
 <!-- 
      For more details about configurations options that may appear in
-     this file, see http://wiki.apache.org/solr/SolrConfigXml. 
+     this file, see https://wiki.apache.org/solr/SolrConfigXml. 
 -->
 <config>
   <!-- In all configuration below, a prefix of "solr." for class names
@@ -201,7 +201,7 @@
                    'simple' is the default
 
          More details on the nuances of each LockFactory...
-         http://wiki.apache.org/lucene-java/AvailableLockFactories
+         https://wiki.apache.org/lucene-java/AvailableLockFactories
     -->
     <lockType>${solr.lock.type:native}</lockType>
 
@@ -254,7 +254,7 @@
        parameters. Remove this to disable exposing Solr configuration
        and statistics to JMX.
 
-       For more details see http://wiki.apache.org/solr/SolrJmx
+       For more details see https://wiki.apache.org/solr/SolrJmx
     -->
   <jmx />
   <!-- If you want to connect to a particular server, specify the
@@ -285,7 +285,7 @@
          Instead of enabling autoCommit, consider using "commitWithin"
          when adding documents.
 
-         http://wiki.apache.org/solr/UpdateXmlMessages
+         https://wiki.apache.org/solr/UpdateXmlMessages
 
          maxDocs - Maximum number of documents to add since the last
                    commit before automatically triggering a new commit.
@@ -336,7 +336,7 @@
       -->
     <!-- This example shows how RunExecutableListener could be used
          with the script based replication...
-         http://wiki.apache.org/solr/CollectionDistribution
+         https://wiki.apache.org/solr/CollectionDistribution
       -->
     <!--
        <listener event="postCommit" class="solr.RunExecutableListener">
@@ -703,7 +703,7 @@
 
   <!-- Request Handlers
 
-       http://wiki.apache.org/solr/SolrRequestHandler
+       https://wiki.apache.org/solr/SolrRequestHandler
 
        Incoming queries will be dispatched to a specific handler by name
        based on the path specified in the request.
@@ -712,7 +712,7 @@
        Handler has that name, and if handleSelect="true" has been specified in
        the requestDispatcher, then the Request Handler is dispatched based on
        the qt parameter.  Handlers without a leading '/' are accessed this way
-       like so: http://host/app/[core/]select?qt=name  If no qt is
+       like so: https://host/app/[core/]select?qt=name  If no qt is
        given, then the requestHandler that declares default="true" will be
        used or the one named "standard".
 
@@ -722,7 +722,7 @@
     -->
   <!-- SearchHandler
 
-       http://wiki.apache.org/solr/SearchHandler
+       https://wiki.apache.org/solr/SearchHandler
 
        For processing Search Queries, the primary Request Handler
        provided with Solr is "SearchHandler" It delegates to a sequent
@@ -820,7 +820,7 @@
 
   <!-- Solr Cell Update Request Handler
 
-       http://wiki.apache.org/solr/ExtractingRequestHandler
+       https://wiki.apache.org/solr/ExtractingRequestHandler
 
     -->
   <requestHandler name="/update/extract"
@@ -881,7 +881,7 @@
        The spell check component can return a list of alternative spelling
        suggestions.
 
-       http://wiki.apache.org/solr/SpellCheckComponent
+       https://wiki.apache.org/solr/SpellCheckComponent
     -->
   <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
 
@@ -938,7 +938,7 @@
        IN OTHER WORDS, THERE IS REALLY GOOD CHANCE THE SETUP BELOW IS
        NOT WHAT YOU WANT FOR YOUR PRODUCTION SYSTEM!
 
-       See http://wiki.apache.org/solr/SpellCheckComponent for details
+       See https://wiki.apache.org/solr/SpellCheckComponent for details
        on the request parameters.
     -->
   <requestHandler name="/spell" class="solr.SearchHandler" startup="lazy">
@@ -965,7 +965,7 @@
 
   <!-- Term Vector Component
 
-       http://wiki.apache.org/solr/TermVectorComponent
+       https://wiki.apache.org/solr/TermVectorComponent
     -->
   <searchComponent name="tvComponent" class="solr.TermVectorComponent"/>
 
@@ -989,7 +989,7 @@
 
   <!-- Terms Component
 
-       http://wiki.apache.org/solr/TermsComponent
+       https://wiki.apache.org/solr/TermsComponent
 
        A component to return terms and document frequency of those
        terms
@@ -1010,7 +1010,7 @@
 
   <!-- Query Elevation Component
 
-       http://wiki.apache.org/solr/QueryElevationComponent
+       https://wiki.apache.org/solr/QueryElevationComponent
 
        a search component that enables you to configure the top
        results for a given query regardless of the normal lucene
@@ -1034,7 +1034,7 @@
 
   <!-- Highlighting Component
 
-       http://wiki.apache.org/solr/HighlightingParameters
+       https://wiki.apache.org/solr/HighlightingParameters
     -->
   <searchComponent class="solr.HighlightComponent" name="highlight">
     <highlighting>
@@ -1144,7 +1144,7 @@
        Requests can be declared, and then used by name in Update
        Request Processors
 
-       http://wiki.apache.org/solr/UpdateRequestProcessor
+       https://wiki.apache.org/solr/UpdateRequestProcessor
 
     -->
 
@@ -1159,7 +1159,7 @@
        declaring schemaFactory as ManagedIndexSchemaFactory, with
        mutable specified as true.
 
-       See http://wiki.apache.org/solr/GuessingFieldTypes
+       See https://wiki.apache.org/solr/GuessingFieldTypes
     -->
   <updateRequestProcessorChain name="files-update-processor">
     <!-- UUIDUpdateProcessorFactory will generate an id if none is present in the incoming document -->
@@ -1249,7 +1249,7 @@
        The fields used for detection are text, title, subject and description,
        making this example suitable for detecting languages form full-text
        rich documents injected via ExtractingRequestHandler.
-       See more about langId at http://wiki.apache.org/solr/LanguageDetection
+       See more about langId at https://wiki.apache.org/solr/LanguageDetection
     -->
   <!--
    <updateRequestProcessorChain name="langid">
@@ -1267,7 +1267,7 @@
 
     This example hooks in an update processor implemented using JavaScript.
 
-    See more about the script update processor at http://wiki.apache.org/solr/ScriptUpdateProcessor
+    See more about the script update processor at https://wiki.apache.org/solr/ScriptUpdateProcessor
   -->
   <!--
     <updateRequestProcessorChain name="script">
@@ -1283,7 +1283,7 @@
 
   <!-- Response Writers
 
-       http://wiki.apache.org/solr/QueryResponseWriter
+       https://wiki.apache.org/solr/QueryResponseWriter
 
        Request responses will be written using the writer specified by
        the 'wt' request parameter matching the name of a registered
@@ -1348,7 +1348,7 @@
 
   <!-- Function Parsers
 
-       http://wiki.apache.org/solr/FunctionQuery
+       https://wiki.apache.org/solr/FunctionQuery
 
        Multiple ValueSourceParsers can be registered by name, and then
        used as function names when using the "func" QParser.
@@ -1361,7 +1361,7 @@
 
 
   <!-- Document Transformers
-       http://wiki.apache.org/solr/DocTransformers
+       https://wiki.apache.org/solr/DocTransformers
     -->
   <!--
      Could be something like:

--- a/src/test/resources/managed-schema/solr.xml
+++ b/src/test/resources/managed-schema/solr.xml
@@ -23,7 +23,7 @@
 
    More information about options available in this configuration file, 
    and Solr Core administration can be found online:
-   http://wiki.apache.org/solr/CoreAdmin
+   https://wiki.apache.org/solr/CoreAdmin
 -->
 
 <solr>

--- a/src/test/resources/org/springframework/data/solr/repository/ITestSolrRepositoryOperations-context.xml
+++ b/src/test/resources/org/springframework/data/solr/repository/ITestSolrRepositoryOperations-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:solr="http://www.springframework.org/schema/data/solr"
 	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/data/solr http://www.springframework.org/schema/data/solr/spring-solr-2.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/data/solr https://www.springframework.org/schema/data/solr/spring-solr-2.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<solr:embedded-solr-server id="solrClient" solrHome="classpath:static-schema" />
 	

--- a/src/test/resources/org/springframework/data/solr/repository/TransactionalSolrRepositoryTest-context.xml
+++ b/src/test/resources/org/springframework/data/solr/repository/TransactionalSolrRepositoryTest-context.xml
@@ -4,10 +4,10 @@
 	xmlns:solr="http://www.springframework.org/schema/data/solr"
 	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/data/solr http://www.springframework.org/schema/data/solr/spring-solr-2.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/data/solr https://www.springframework.org/schema/data/solr/spring-solr-2.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
 	<bean id="solrClient" class="org.springframework.data.solr.test.util.GenericMockFactory">
 		<property name="type" value="org.apache.solr.client.solrj.SolrClient" />

--- a/src/test/resources/org/springframework/data/solr/repository/config/namespace.xml
+++ b/src/test/resources/org/springframework/data/solr/repository/config/namespace.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:solr="http://www.springframework.org/schema/data/solr"
-	xsi:schemaLocation="http://www.springframework.org/schema/data/solr http://www.springframework.org/schema/data/solr/spring-solr-2.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/data/solr https://www.springframework.org/schema/data/solr/spring-solr-2.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<solr:repositories base-package="org.springframework.data.solr.repository.config" />
 	<solr:embedded-solr-server id="solrClient" solrHome="classpath:static-schema" />

--- a/src/test/resources/static-schema/collection1/conf/clustering/carrot2/kmeans-attributes.xml
+++ b/src/test/resources/static-schema/collection1/conf/clustering/carrot2/kmeans-attributes.xml
@@ -2,7 +2,7 @@
   Default configuration for the bisecting k-means clustering algorithm.
   
   This file can be loaded (and saved) by Carrot2 Workbench.
-  http://project.carrot2.org/download.html
+  https://project.carrot2.org/download.html
 -->
 <attribute-sets default="attributes">
     <attribute-set id="attributes">

--- a/src/test/resources/static-schema/collection1/conf/clustering/carrot2/lingo-attributes.xml
+++ b/src/test/resources/static-schema/collection1/conf/clustering/carrot2/lingo-attributes.xml
@@ -2,7 +2,7 @@
   Default configuration for the Lingo clustering algorithm.
 
   This file can be loaded (and saved) by Carrot2 Workbench.
-  http://project.carrot2.org/download.html
+  https://project.carrot2.org/download.html
 -->
 <attribute-sets default="attributes">
     <attribute-set id="attributes">
@@ -11,7 +11,7 @@
           <!-- 
           The language to assume for clustered documents.
           For a list of allowed values, see: 
-          http://download.carrot2.org/stable/manual/#section.attribute.lingo.MultilingualClustering.defaultLanguage
+          https://download.carrot2.org/stable/manual/#section.attribute.lingo.MultilingualClustering.defaultLanguage
           -->
           <attribute key="MultilingualClustering.defaultLanguage">
             <value type="org.carrot2.core.LanguageCode" value="ENGLISH"/>

--- a/src/test/resources/static-schema/collection1/conf/clustering/carrot2/stc-attributes.xml
+++ b/src/test/resources/static-schema/collection1/conf/clustering/carrot2/stc-attributes.xml
@@ -2,7 +2,7 @@
   Default configuration for the STC clustering algorithm.
 
   This file can be loaded (and saved) by Carrot2 Workbench.
-  http://project.carrot2.org/download.html
+  https://project.carrot2.org/download.html
 -->
 <attribute-sets default="attributes">
     <attribute-set id="attributes">

--- a/src/test/resources/static-schema/collection1/conf/elevate.xml
+++ b/src/test/resources/static-schema/collection1/conf/elevate.xml
@@ -20,7 +20,7 @@
      loaded once at startup.  If it is found in Solr's data
      directory, it will be re-loaded every commit.
 
-   See http://wiki.apache.org/solr/QueryElevationComponent for more info
+   See https://wiki.apache.org/solr/QueryElevationComponent for more info
 
 -->
 <elevate>

--- a/src/test/resources/static-schema/collection1/conf/schema.xml
+++ b/src/test/resources/static-schema/collection1/conf/schema.xml
@@ -26,7 +26,7 @@
  It should be kept correct and concise, usable out-of-the-box.
 
  For more information, on how to customize this file, please see
- http://wiki.apache.org/solr/SchemaXml
+ https://wiki.apache.org/solr/SchemaXml
 
  PERFORMANCE NOTE: this schema includes many optional features and should not
  be used for benchmarking.  To improve performance one could
@@ -399,7 +399,7 @@
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
-         http://www.w3.org/TR/xmlschema-2/#dateTime
+         https://www.w3.org/TR/xmlschema-2/#dateTime
          The trailing "Z" designates UTC time and is mandatory.
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
          All other components are mandatory.
@@ -452,7 +452,7 @@
          matching across fields.
 
          For more info on customizing your analyzer chain, please see
-         http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters
+         https://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters
      -->
 
     <!-- One can also specify an existing Analyzer class that has a
@@ -653,7 +653,7 @@
                  See the Java Regular Expression documentation for more
                  information on pattern and replacement string syntax.
 
-                 http://docs.oracle.com/javase/8/docs/api/java/util/regex/package-summary.html
+                 https://docs.oracle.com/javase/8/docs/api/java/util/regex/package-summary.html
               -->
             <filter class="solr.PatternReplaceFilterFactory"
                     pattern="([^a-z])" replacement="" replace="all"
@@ -741,7 +741,7 @@
 
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:
-      http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
+      https://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
     -->
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
                geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="kilometers" />
@@ -753,7 +753,7 @@
                geo="true" distanceUnits="kilometers" numberType="_bbox_coord" />
     <fieldType name="_bbox_coord" class="solr.TrieDoubleField" precisionStep="8" docValues="true" useDocValuesAsStored="false" stored="false" />
 
-    <!-- Money/currency field type. See http://wiki.apache.org/solr/MoneyFieldType
+    <!-- Money/currency field type. See https://wiki.apache.org/solr/MoneyFieldType
          Parameters:
            defaultCurrency: Specifies the default currency if none specified. Defaults to "USD"
            precisionStep:   Specifies the precisionStep for the TrieLong field used for the amount
@@ -1050,7 +1050,7 @@
 
                  Punctuation characters are discarded by default.  Use discardPunctuation="false" to keep them.
 
-                 See http://wiki.apache.org/solr/JapaneseLanguageSupport for more on Japanese language support.
+                 See https://wiki.apache.org/solr/JapaneseLanguageSupport for more on Japanese language support.
               -->
             <tokenizer class="solr.JapaneseTokenizerFactory" mode="search"/>
             <!--<tokenizer class="solr.JapaneseTokenizerFactory" mode="search" userDictionary="lang/userdict_ja.txt"/>-->
@@ -1179,7 +1179,7 @@
     <!-- Similarity is the scoring routine for each document vs. a query.
          A custom Similarity or SimilarityFactory may be specified here, but
          the default is fine for most applications.
-         For more info: http://wiki.apache.org/solr/SchemaXml#Similarity
+         For more info: https://wiki.apache.org/solr/SchemaXml#Similarity
       -->
     <!--
        <similarity class="com.example.solr.CustomSimilarityFactory">

--- a/src/test/resources/static-schema/collection1/conf/solrconfig.xml
+++ b/src/test/resources/static-schema/collection1/conf/solrconfig.xml
@@ -18,7 +18,7 @@
 
 <!--
      For more details about configurations options that may appear in
-     this file, see http://wiki.apache.org/solr/SolrConfigXml.
+     this file, see https://wiki.apache.org/solr/SolrConfigXml.
 -->
 <config>
   <!-- In all configuration below, a prefix of "solr." for class names
@@ -206,7 +206,7 @@
                    'simple' is the default
 
          More details on the nuances of each LockFactory...
-         http://wiki.apache.org/lucene-java/AvailableLockFactories
+         https://wiki.apache.org/lucene-java/AvailableLockFactories
     -->
     <lockType>${solr.lock.type:none}</lockType>
 
@@ -260,7 +260,7 @@
        parameters. Remove this to disable exposing Solr configuration
        and statistics to JMX.
 
-       For more details see http://wiki.apache.org/solr/SolrJmx
+       For more details see https://wiki.apache.org/solr/SolrJmx
     -->
   <jmx />
   <!-- If you want to connect to a particular server, specify the
@@ -298,7 +298,7 @@
          Instead of enabling autoCommit, consider using "commitWithin"
          when adding documents.
 
-         http://wiki.apache.org/solr/UpdateXmlMessages
+         https://wiki.apache.org/solr/UpdateXmlMessages
 
          maxDocs - Maximum number of documents to add since the last
                    commit before automatically triggering a new commit.
@@ -700,7 +700,7 @@
 
   <!-- Request Handlers
 
-       http://wiki.apache.org/solr/SolrRequestHandler
+       https://wiki.apache.org/solr/SolrRequestHandler
 
        Incoming queries will be dispatched to a specific handler by name
        based on the path specified in the request.
@@ -711,7 +711,7 @@
     -->
   <!-- SearchHandler
 
-       http://wiki.apache.org/solr/SearchHandler
+       https://wiki.apache.org/solr/SearchHandler
 
        For processing Search Queries, the primary Request Handler
        provided with Solr is "SearchHandler" It delegates to a sequent
@@ -943,7 +943,7 @@
 
   <!-- Solr Cell Update Request Handler
 
-       http://wiki.apache.org/solr/ExtractingRequestHandler
+       https://wiki.apache.org/solr/ExtractingRequestHandler
 
     -->
   <requestHandler name="/update/extract"
@@ -1008,7 +1008,7 @@
         The spell check component can return a list of alternative spelling
         suggestions.
 
-        http://wiki.apache.org/solr/SpellCheckComponent
+        https://wiki.apache.org/solr/SpellCheckComponent
      -->
   <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
 
@@ -1102,7 +1102,7 @@
        IN OTHER WORDS, THERE IS REALLY GOOD CHANCE THE SETUP BELOW IS
        NOT WHAT YOU WANT FOR YOUR PRODUCTION SYSTEM!
 
-       See http://wiki.apache.org/solr/SpellCheckComponent for details
+       See https://wiki.apache.org/solr/SpellCheckComponent for details
        on the request parameters.
     -->
   <requestHandler name="/spell" class="solr.SearchHandler" startup="lazy">
@@ -1135,7 +1135,7 @@
 
        More information about this component and other configuration options are described in the
        "Suggester" section of the reference guide available at
-       http://archive.apache.org/dist/lucene/solr/ref-guide
+       https://archive.apache.org/dist/lucene/solr/ref-guide
     -->
   <searchComponent name="suggest" class="solr.SuggestComponent">
     <lst name="suggester">
@@ -1163,7 +1163,7 @@
 
   <!-- Term Vector Component
 
-       http://wiki.apache.org/solr/TermVectorComponent
+       https://wiki.apache.org/solr/TermVectorComponent
     -->
   <searchComponent name="tvComponent" class="solr.TermVectorComponent"/>
 
@@ -1201,7 +1201,7 @@
       * org.carrot2.clustering.lingo.LingoClusteringAlgorithm
       * org.carrot2.clustering.stc.STCClusteringAlgorithm
       * org.carrot2.clustering.kmeans.BisectingKMeansClusteringAlgorithm
-    See http://project.carrot2.org/algorithms.html for more information.
+    See https://project.carrot2.org/algorithms.html for more information.
 
     Commercial algorithm Lingo3G (needs to be installed separately):
       * com.carrotsearch.lingo3g.Lingo3GClusteringAlgorithm
@@ -1274,7 +1274,7 @@
 
   <!-- Terms Component
 
-       http://wiki.apache.org/solr/TermsComponent
+       https://wiki.apache.org/solr/TermsComponent
 
        A component to return terms and document frequency of those
        terms
@@ -1295,7 +1295,7 @@
 
   <!-- Query Elevation Component
 
-       http://wiki.apache.org/solr/QueryElevationComponent
+       https://wiki.apache.org/solr/QueryElevationComponent
 
        a search component that enables you to configure the top
        results for a given query regardless of the normal lucene
@@ -1319,7 +1319,7 @@
 
   <!-- Highlighting Component
 
-       http://wiki.apache.org/solr/HighlightingParameters
+       https://wiki.apache.org/solr/HighlightingParameters
     -->
   <searchComponent class="solr.HighlightComponent" name="highlight">
     <highlighting>
@@ -1429,7 +1429,7 @@
        Requests can be declared, and then used by name in Update
        Request Processors
 
-       http://wiki.apache.org/solr/UpdateRequestProcessor
+       https://wiki.apache.org/solr/UpdateRequestProcessor
 
     -->
   <!-- Deduplication
@@ -1463,7 +1463,7 @@
        The fields used for detection are text, title, subject and description,
        making this example suitable for detecting languages form full-text
        rich documents injected via ExtractingRequestHandler.
-       See more about langId at http://wiki.apache.org/solr/LanguageDetection
+       See more about langId at https://wiki.apache.org/solr/LanguageDetection
     -->
     <!--
      <updateRequestProcessorChain name="langid">
@@ -1481,7 +1481,7 @@
 
     This example hooks in an update processor implemented using JavaScript.
 
-    See more about the script update processor at http://wiki.apache.org/solr/ScriptUpdateProcessor
+    See more about the script update processor at https://wiki.apache.org/solr/ScriptUpdateProcessor
   -->
   <!--
     <updateRequestProcessorChain name="script">
@@ -1497,7 +1497,7 @@
 
   <!-- Response Writers
 
-       http://wiki.apache.org/solr/QueryResponseWriter
+       https://wiki.apache.org/solr/QueryResponseWriter
 
        Request responses will be written using the writer specified by
        the 'wt' request parameter matching the name of a registered
@@ -1561,7 +1561,7 @@
 
   <!-- Function Parsers
 
-       http://wiki.apache.org/solr/FunctionQuery
+       https://wiki.apache.org/solr/FunctionQuery
 
        Multiple ValueSourceParsers can be registered by name, and then
        used as function names when using the "func" QParser.
@@ -1585,7 +1585,7 @@
   <queryParser enable="${solr.ltr.enabled:false}" name="ltr" class="org.apache.solr.ltr.search.LTRQParserPlugin"/>
 
   <!-- Document Transformers
-       http://wiki.apache.org/solr/DocTransformers
+       https://wiki.apache.org/solr/DocTransformers
     -->
   <!--
      Could be something like:

--- a/src/test/resources/static-schema/solr.xml
+++ b/src/test/resources/static-schema/solr.xml
@@ -23,7 +23,7 @@
 
    More information about options available in this configuration file, 
    and Solr Core administration can be found online:
-   http://wiki.apache.org/solr/CoreAdmin
+   https://wiki.apache.org/solr/CoreAdmin
 -->
 
 <solr>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.exchangerate.com/ (200) with 2 occurrences could not be migrated:  
   ([https](https://www.exchangerate.com/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://host/app/ (UnknownHostException) with 1 occurrences migrated to:  
  https://host/app/ ([https](https://host/app/) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.oracle.com/javase/8/docs/api/java/util/regex/package-summary.html with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/8/docs/api/java/util/regex/package-summary.html ([https](https://docs.oracle.com/javase/8/docs/api/java/util/regex/package-summary.html) result 200).
* http://download.carrot2.org/stable/manual/ with 1 occurrences migrated to:  
  https://download.carrot2.org/stable/manual/ ([https](https://download.carrot2.org/stable/manual/) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://project.carrot2.org/algorithms.html with 1 occurrences migrated to:  
  https://project.carrot2.org/algorithms.html ([https](https://project.carrot2.org/algorithms.html) result 200).
* http://project.carrot2.org/download.html with 3 occurrences migrated to:  
  https://project.carrot2.org/download.html ([https](https://project.carrot2.org/download.html) result 200).
* http://wiki.apache.org/lucene-java/AvailableLockFactories with 2 occurrences migrated to:  
  https://wiki.apache.org/lucene-java/AvailableLockFactories ([https](https://wiki.apache.org/lucene-java/AvailableLockFactories) result 200).
* http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters with 1 occurrences migrated to:  
  https://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters ([https](https://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters) result 200).
* http://wiki.apache.org/solr/CollectionDistribution with 1 occurrences migrated to:  
  https://wiki.apache.org/solr/CollectionDistribution ([https](https://wiki.apache.org/solr/CollectionDistribution) result 200).
* http://wiki.apache.org/solr/CoreAdmin with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/CoreAdmin ([https](https://wiki.apache.org/solr/CoreAdmin) result 200).
* http://wiki.apache.org/solr/DocTransformers with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/DocTransformers ([https](https://wiki.apache.org/solr/DocTransformers) result 200).
* http://wiki.apache.org/solr/ExtractingRequestHandler with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/ExtractingRequestHandler ([https](https://wiki.apache.org/solr/ExtractingRequestHandler) result 200).
* http://wiki.apache.org/solr/FunctionQuery with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/FunctionQuery ([https](https://wiki.apache.org/solr/FunctionQuery) result 200).
* http://wiki.apache.org/solr/GuessingFieldTypes with 1 occurrences migrated to:  
  https://wiki.apache.org/solr/GuessingFieldTypes ([https](https://wiki.apache.org/solr/GuessingFieldTypes) result 200).
* http://wiki.apache.org/solr/HighlightingParameters with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/HighlightingParameters ([https](https://wiki.apache.org/solr/HighlightingParameters) result 200).
* http://wiki.apache.org/solr/JapaneseLanguageSupport with 1 occurrences migrated to:  
  https://wiki.apache.org/solr/JapaneseLanguageSupport ([https](https://wiki.apache.org/solr/JapaneseLanguageSupport) result 200).
* http://wiki.apache.org/solr/LanguageDetection with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/LanguageDetection ([https](https://wiki.apache.org/solr/LanguageDetection) result 200).
* http://wiki.apache.org/solr/QueryElevationComponent with 4 occurrences migrated to:  
  https://wiki.apache.org/solr/QueryElevationComponent ([https](https://wiki.apache.org/solr/QueryElevationComponent) result 200).
* http://wiki.apache.org/solr/QueryResponseWriter with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/QueryResponseWriter ([https](https://wiki.apache.org/solr/QueryResponseWriter) result 200).
* http://wiki.apache.org/solr/SchemaXml with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/SchemaXml ([https](https://wiki.apache.org/solr/SchemaXml) result 200).
* http://wiki.apache.org/solr/ScriptUpdateProcessor with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/ScriptUpdateProcessor ([https](https://wiki.apache.org/solr/ScriptUpdateProcessor) result 200).
* http://wiki.apache.org/solr/SearchHandler with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/SearchHandler ([https](https://wiki.apache.org/solr/SearchHandler) result 200).
* http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4 with 1 occurrences migrated to:  
  https://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4 ([https](https://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4) result 200).
* http://wiki.apache.org/solr/SolrConfigXml with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/SolrConfigXml ([https](https://wiki.apache.org/solr/SolrConfigXml) result 200).
* http://wiki.apache.org/solr/SolrJmx with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/SolrJmx ([https](https://wiki.apache.org/solr/SolrJmx) result 200).
* http://wiki.apache.org/solr/SolrRequestHandler with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/SolrRequestHandler ([https](https://wiki.apache.org/solr/SolrRequestHandler) result 200).
* http://wiki.apache.org/solr/SpellCheckComponent with 4 occurrences migrated to:  
  https://wiki.apache.org/solr/SpellCheckComponent ([https](https://wiki.apache.org/solr/SpellCheckComponent) result 200).
* http://wiki.apache.org/solr/TermVectorComponent with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/TermVectorComponent ([https](https://wiki.apache.org/solr/TermVectorComponent) result 200).
* http://wiki.apache.org/solr/TermsComponent with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/TermsComponent ([https](https://wiki.apache.org/solr/TermsComponent) result 200).
* http://wiki.apache.org/solr/UpdateRequestProcessor with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/UpdateRequestProcessor ([https](https://wiki.apache.org/solr/UpdateRequestProcessor) result 200).
* http://wiki.apache.org/solr/UpdateXmlMessages with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/UpdateXmlMessages ([https](https://wiki.apache.org/solr/UpdateXmlMessages) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/data/solr/spring-solr-2.0.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/data/solr/spring-solr-2.0.xsd ([https](https://www.springframework.org/schema/data/solr/spring-solr-2.0.xsd) result 200).
* http://www.springframework.org/schema/jdbc/spring-jdbc.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).
* http://www.w3.org/TR/xmlschema-2/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/xmlschema-2/ ([https](https://www.w3.org/TR/xmlschema-2/) result 200).
* http://archive.apache.org/dist/lucene/solr/ref-guide with 1 occurrences migrated to:  
  https://archive.apache.org/dist/lucene/solr/ref-guide ([https](https://archive.apache.org/dist/lucene/solr/ref-guide) result 301).
* http://wiki.apache.org/solr/MoneyFieldType with 1 occurrences migrated to:  
  https://wiki.apache.org/solr/MoneyFieldType ([https](https://wiki.apache.org/solr/MoneyFieldType) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8983/solr with 1 occurrences
* http://localhost:8983/solr,http://127.0.0.1:8983/solr with 1 occurrences
* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.springframework.org/schema/beans with 6 occurrences
* http://www.springframework.org/schema/data/solr with 6 occurrences
* http://www.springframework.org/schema/jdbc with 2 occurrences
* http://www.springframework.org/schema/util with 4 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences