### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,4 +24,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-[![Spring Data for Apache Solr](https://spring.io/badges/spring-data-solr/ga.svg)](http://projects.spring.io/spring-data-solr/#quick-start)
-[![Spring Data for Apache Solr](https://spring.io/badges/spring-data-solr/snapshot.svg)](http://projects.spring.io/spring-data-solr/#quick-start)
+[![Spring Data for Apache Solr](https://spring.io/badges/spring-data-solr/ga.svg)](https://projects.spring.io/spring-data-solr/#quick-start)
+[![Spring Data for Apache Solr](https://spring.io/badges/spring-data-solr/snapshot.svg)](https://projects.spring.io/spring-data-solr/#quick-start)
 
 Spring Data for Apache Solr
 ===========================
 
-The primary goal of the [Spring Data](http://projects.spring.io/spring-data) project is to make it easier to build Spring-powered applications that use new data access technologies such as non-relational databases, map-reduce frameworks, and cloud based data services.
+The primary goal of the [Spring Data](https://projects.spring.io/spring-data) project is to make it easier to build Spring-powered applications that use new data access technologies such as non-relational databases, map-reduce frameworks, and cloud based data services.
 
-The Spring Data for Apache Solr project provides integration with the [Apache Solr](http://lucene.apache.org/solr/) search engine 
+The Spring Data for Apache Solr project provides integration with the [Apache Solr](https://lucene.apache.org/solr/) search engine 
 
 Providing its own extensible ```MappingSolrConverter``` as alternative to ```DocumentObjectBinder``` Spring Data for Apache Solr handles inheritance as well as usage of custom Types such as  ```Point``` or ```DateTime```.
 
 Getting Help
 ------------
 
-* [Reference Documentation](http://docs.spring.io/spring-data/data-solr/docs/current/reference/html/)
-* [API Documentation](http://docs.spring.io/spring-data/data-solr/docs/current/api/)
-* [Spring Data Project](http://projects.spring.io/spring-data)
+* [Reference Documentation](https://docs.spring.io/spring-data/data-solr/docs/current/reference/html/)
+* [API Documentation](https://docs.spring.io/spring-data/data-solr/docs/current/api/)
+* [Spring Data Project](https://projects.spring.io/spring-data)
 * [Issues](https://jira.springsource.org/browse/DATASOLR)
 * [Code Analysis](https://sonar.springsource.org/dashboard/index/org.springframework.data:spring-data-solr)
-* [Questions](http://stackoverflow.com/questions/tagged/spring-data-solr)
+* [Questions](https://stackoverflow.com/questions/tagged/spring-data-solr)
 
 If you are new to Spring as well as to Spring Data, look for information about [Spring projects](https://spring.io/projects).
 
@@ -176,8 +176,8 @@ You can set up repository scanning via xml configuration, which will happily cre
 <beans xmlns="http://www.springframework.org/schema/beans"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:solr="http://www.springframework.org/schema/data/solr"
-  xsi:schemaLocation="http://www.springframework.org/schema/data/solr http://www.springframework.org/schema/data/solr/spring-solr.xsd
-    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+  xsi:schemaLocation="http://www.springframework.org/schema/data/solr https://www.springframework.org/schema/data/solr/spring-solr.xsd
+    http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
   
   <solr:repositories base-package="com.acme.repository" />
   <solr:solr-client id="solrClient" url="http://localhost:8983/solr" />
@@ -263,7 +263,7 @@ Maven
 
 <repository>
   <id>spring-maven-snapshot</id>
-  <url>http://repo.spring.io/libs-snapshot</url>
+  <url>https://repo.spring.io/libs-snapshot</url>
 </repository>  
 ```
 
@@ -271,10 +271,10 @@ Maven
 
 Here are some ways for you to get involved in the community:
 
-* Get involved with the Spring community on Stackoverflow and help out on the [spring-data-solr](http://stackoverflow.com/questions/tagged/spring-data-solr) tag by responding to questions and joining the debate.
+* Get involved with the Spring community on Stackoverflow and help out on the [spring-data-solr](https://stackoverflow.com/questions/tagged/spring-data-solr) tag by responding to questions and joining the debate.
 * Create [JIRA](https://jira.spring.io/browse/DATASOLR) tickets for bugs and new features and comment and vote on the ones that you are interested in.  
-* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/). If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
-* Watch for upcoming articles on Spring by [subscribing](http://spring.io/blog) to spring.io.
+* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](https://help.github.com/forking/). If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
+* Watch for upcoming articles on Spring by [subscribing](https://spring.io/blog) to spring.io.
 
 Before we accept a non-trivial patch or pull request we will need you to [sign the Contributor License Agreement](https://cla.pivotal.io/sign/spring). Signing the contributor’s agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. If you forget to do so, you'll be reminded when you submit a pull request. Active contributors might be asked to join the core team, and given the ability to merge pull requests.
 

--- a/src/main/asciidoc/preface.adoc
+++ b/src/main/asciidoc/preface.adoc
@@ -16,7 +16,7 @@ The Spring Data for Apache Solr project applies core Spring concepts to the deve
 [preface]
 == Requirements
 
-Spring Data Solr requires Java 8 runtime and http://lucene.apache.org/solr/[Apache Solr] 8.0. We recommend using the latest 8.0.x version.
+Spring Data Solr requires Java 8 runtime and https://lucene.apache.org/solr/[Apache Solr] 8.0. We recommend using the latest 8.0.x version.
 
 The following Maven dependency snippet shows how to include Apache Solr in your project:
 

--- a/src/main/asciidoc/reference/data-solr.adoc
+++ b/src/main/asciidoc/reference/data-solr.adoc
@@ -21,9 +21,9 @@ The following example shows how to set up Solr repositories that use the Spring 
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:solr="http://www.springframework.org/schema/data/solr"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/data/solr
-    http://www.springframework.org/schema/data/solr/spring-solr.xsd">
+    https://www.springframework.org/schema/data/solr/spring-solr.xsd">
 
   <solr:repositories base-package="com.acme.repositories" />
 </beans>
@@ -43,11 +43,11 @@ The following examples shows how to set up a Solr client for HTTP:
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:solr="http://www.springframework.org/schema/data/solr"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/data/solr
-    http://www.springframework.org/schema/data/solr/spring-solr.xsd">
+    https://www.springframework.org/schema/data/solr/spring-solr.xsd">
 
-  <solr:solr-client id="solrClient" url="http://locahost:8983/solr" />
+  <solr:solr-client id="solrClient" url="https://locahost:8983/solr" />
 </beans>
 ----
 ====
@@ -63,11 +63,11 @@ The following example shows how to set up a load-balancing Solr client:
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:solr="http://www.springframework.org/schema/data/solr"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/data/solr
-    http://www.springframework.org/schema/data/solr/spring-solr.xsd">
+    https://www.springframework.org/schema/data/solr/spring-solr.xsd">
 
-  <solr:solr-client id="solrClient" url="http://locahost:8983/solr,http://localhost:8984/solr" />
+  <solr:solr-client id="solrClient" url="https://locahost:8983/solr,http://localhost:8984/solr" />
 </beans>
 ----
 ====
@@ -83,9 +83,9 @@ The following example shows how to set up an embedded Solr server:
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:solr="http://www.springframework.org/schema/data/solr"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
-    http://www.springframework.org/schema/beans/spring-beans.xsd
+    https://www.springframework.org/schema/beans/spring-beans.xsd
     http://www.springframework.org/schema/data/solr
-    http://www.springframework.org/schema/data/solr/spring-solr.xsd">
+    https://www.springframework.org/schema/data/solr/spring-solr.xsd">
 
   <solr:embedded-solr-server id="solrClient" solrHome="classpath:com/acme/solr" />
 </beans>

--- a/src/main/resources/license.txt
+++ b/src/main/resources/license.txt
@@ -207,7 +207,7 @@ similar licenses that require the source code and/or modifications to
 source code to be made available (as would be noted above), you may obtain a 
 copy of the source code corresponding to the binaries for such open source 
 components and modifications thereto, if any, (the "Source Files"), by 
-downloading the Source Files from http://www.springsource.org/download, 
+downloading the Source Files from https://www.springsource.org/download, 
 or by sending a request, with your name and address to: VMware, Inc., 3401 Hillview 
 Avenue, Palo Alto, CA 94304, United States of America or email info@vmware.com.  All 
 such requests should clearly specify:  OPEN SOURCE FILES REQUEST, Attention General 

--- a/src/main/resources/org/springframework/data/solr/config/spring-solr-1.0.xsd
+++ b/src/main/resources/org/springframework/data/solr/config/spring-solr-1.0.xsd
@@ -10,7 +10,7 @@
 	<xsd:import namespace="http://www.springframework.org/schema/beans" />
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/data/repository"
-		schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd" />	
+		schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd" />	
 
 	<xsd:element name="repositories">
 		<xsd:complexType>

--- a/src/main/resources/org/springframework/data/solr/config/spring-solr-2.0.xsd
+++ b/src/main/resources/org/springframework/data/solr/config/spring-solr-2.0.xsd
@@ -10,7 +10,7 @@
 	<xsd:import namespace="http://www.springframework.org/schema/beans" />
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/data/repository"
-		schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd" />	
+		schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd" />	
 
 	<xsd:element name="repositories">
 		<xsd:complexType>

--- a/src/main/resources/org/springframework/data/solr/config/spring-solr-3.0.xsd
+++ b/src/main/resources/org/springframework/data/solr/config/spring-solr-3.0.xsd
@@ -10,7 +10,7 @@
 	<xsd:import namespace="http://www.springframework.org/schema/beans" />
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/data/repository"
-		schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd" />	
+		schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd" />	
 
 	<xsd:element name="repositories">
 		<xsd:complexType>

--- a/src/main/resources/org/springframework/data/solr/config/spring-solr-4.0.xsd
+++ b/src/main/resources/org/springframework/data/solr/config/spring-solr-4.0.xsd
@@ -10,7 +10,7 @@
 	<xsd:import namespace="http://www.springframework.org/schema/beans" />
 	<xsd:import namespace="http://www.springframework.org/schema/tool" />
 	<xsd:import namespace="http://www.springframework.org/schema/data/repository"
-		schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd" />	
+		schemaLocation="https://www.springframework.org/schema/data/repository/spring-repository.xsd" />	
 
 	<xsd:element name="repositories">
 		<xsd:complexType>

--- a/src/test/java/org/springframework/data/solr/HttpSolrClientFactoryTests.java
+++ b/src/test/java/org/springframework/data/solr/HttpSolrClientFactoryTests.java
@@ -35,7 +35,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  */
 public class HttpSolrClientFactoryTests {
 
-	private static final String URL = "http://solr.server.url";
+	private static final String URL = "https://solr.server.url";
 	private SolrClient solrClient;
 
 	@Before

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_ar.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_ar.txt
@@ -1,6 +1,6 @@
 # This file was created by Jacques Savoy and is distributed under the BSD license.
 # See http://members.unine.ch/jacques.savoy/clef/index.html.
-# Also see http://www.opensource.org/licenses/bsd-license.html
+# Also see https://www.opensource.org/licenses/bsd-license.html
 # Cleaned on October 11, 2009 (not normalized, so use before normalization)
 # This means that when modifying this list, you might need to add some 
 # redundant entries, for example containing forms with both أ and ا

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_bg.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_bg.txt
@@ -1,6 +1,6 @@
 # This file was created by Jacques Savoy and is distributed under the BSD license.
 # See http://members.unine.ch/jacques.savoy/clef/index.html.
-# Also see http://www.opensource.org/licenses/bsd-license.html
+# Also see https://www.opensource.org/licenses/bsd-license.html
 а
 аз
 ако

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_ca.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_ca.txt
@@ -1,4 +1,4 @@
-# Catalan stopwords from http://github.com/vcl/cue.language (Apache 2 Licensed)
+# Catalan stopwords from https://github.com/vcl/cue.language (Apache 2 Licensed)
 a
 abans
 ací

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_da.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_da.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/danish/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_de.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_de.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/german/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_es.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_es.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/spanish/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_fa.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_fa.txt
@@ -1,6 +1,6 @@
 # This file was created by Jacques Savoy and is distributed under the BSD license.
 # See http://members.unine.ch/jacques.savoy/clef/index.html.
-# Also see http://www.opensource.org/licenses/bsd-license.html
+# Also see https://www.opensource.org/licenses/bsd-license.html
 # Note: by default this file is used after normalization, so when adding entries
 # to this file, use the arabic 'ي' instead of 'ی'
 انان

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_fi.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_fi.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/finnish/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_fr.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_fr.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/french/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_hi.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_hi.txt
@@ -1,4 +1,4 @@
-# Also see http://www.opensource.org/licenses/bsd-license.html
+# Also see https://www.opensource.org/licenses/bsd-license.html
 # See http://members.unine.ch/jacques.savoy/clef/index.html.
 # This file was created by Jacques Savoy and is distributed under the BSD license.
 # Note: by default this file also contains forms normalized by HindiNormalizer 

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_hu.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_hu.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/hungarian/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_it.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_it.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/italian/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_nl.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_nl.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/dutch/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_no.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_no.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/norwegian/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_pt.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_pt.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/portuguese/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_ro.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_ro.txt
@@ -1,6 +1,6 @@
 # This file was created by Jacques Savoy and is distributed under the BSD license.
 # See http://members.unine.ch/jacques.savoy/clef/index.html.
-# Also see http://www.opensource.org/licenses/bsd-license.html
+# Also see https://www.opensource.org/licenses/bsd-license.html
 acea
 aceasta
 această

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_ru.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_ru.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/russian/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_sv.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_sv.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/swedish/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/managed-schema/collection1/conf/lang/stopwords_tr.txt
+++ b/src/test/resources/managed-schema/collection1/conf/lang/stopwords_tr.txt
@@ -1,6 +1,6 @@
 # Turkish stopwords from LUCENE-559
 # merged with the list from "Information Retrieval on Turkish Texts"
-#   (http://www.users.muohio.edu/canf/papers/JASIST2008offPrint.pdf)
+#   (https://www.users.muohio.edu/canf/papers/JASIST2008offPrint.pdf)
 acaba
 altmış
 altı

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_ar.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_ar.txt
@@ -1,6 +1,6 @@
 # This file was created by Jacques Savoy and is distributed under the BSD license.
 # See http://members.unine.ch/jacques.savoy/clef/index.html.
-# Also see http://www.opensource.org/licenses/bsd-license.html
+# Also see https://www.opensource.org/licenses/bsd-license.html
 # Cleaned on October 11, 2009 (not normalized, so use before normalization)
 # This means that when modifying this list, you might need to add some 
 # redundant entries, for example containing forms with both أ and ا

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_bg.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_bg.txt
@@ -1,6 +1,6 @@
 # This file was created by Jacques Savoy and is distributed under the BSD license.
 # See http://members.unine.ch/jacques.savoy/clef/index.html.
-# Also see http://www.opensource.org/licenses/bsd-license.html
+# Also see https://www.opensource.org/licenses/bsd-license.html
 а
 аз
 ако

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_ca.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_ca.txt
@@ -1,4 +1,4 @@
-# Catalan stopwords from http://github.com/vcl/cue.language (Apache 2 Licensed)
+# Catalan stopwords from https://github.com/vcl/cue.language (Apache 2 Licensed)
 a
 abans
 ací

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_da.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_da.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/danish/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_de.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_de.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/german/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_es.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_es.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/spanish/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_fa.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_fa.txt
@@ -1,6 +1,6 @@
 # This file was created by Jacques Savoy and is distributed under the BSD license.
 # See http://members.unine.ch/jacques.savoy/clef/index.html.
-# Also see http://www.opensource.org/licenses/bsd-license.html
+# Also see https://www.opensource.org/licenses/bsd-license.html
 # Note: by default this file is used after normalization, so when adding entries
 # to this file, use the arabic 'ي' instead of 'ی'
 انان

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_fi.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_fi.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/finnish/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_fr.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_fr.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/french/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_hi.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_hi.txt
@@ -1,4 +1,4 @@
-# Also see http://www.opensource.org/licenses/bsd-license.html
+# Also see https://www.opensource.org/licenses/bsd-license.html
 # See http://members.unine.ch/jacques.savoy/clef/index.html.
 # This file was created by Jacques Savoy and is distributed under the BSD license.
 # Note: by default this file also contains forms normalized by HindiNormalizer 

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_hu.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_hu.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/hungarian/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_it.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_it.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/italian/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_nl.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_nl.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/dutch/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_no.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_no.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/norwegian/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_pt.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_pt.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/portuguese/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_ro.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_ro.txt
@@ -1,6 +1,6 @@
 # This file was created by Jacques Savoy and is distributed under the BSD license.
 # See http://members.unine.ch/jacques.savoy/clef/index.html.
-# Also see http://www.opensource.org/licenses/bsd-license.html
+# Also see https://www.opensource.org/licenses/bsd-license.html
 acea
 aceasta
 această

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_ru.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_ru.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/russian/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_sv.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_sv.txt
@@ -1,7 +1,7 @@
  | From svn.tartarus.org/snowball/trunk/website/algorithms/swedish/stop.txt
  | This file is distributed under the BSD License.
  | See http://snowball.tartarus.org/license.php
- | Also see http://www.opensource.org/licenses/bsd-license.html
+ | Also see https://www.opensource.org/licenses/bsd-license.html
  |  - Encoding was converted to UTF-8.
  |  - This notice was added.
  |

--- a/src/test/resources/static-schema/collection1/conf/lang/stopwords_tr.txt
+++ b/src/test/resources/static-schema/collection1/conf/lang/stopwords_tr.txt
@@ -1,6 +1,6 @@
 # Turkish stopwords from LUCENE-559
 # merged with the list from "Information Retrieval on Turkish Texts"
-#   (http://www.users.muohio.edu/canf/papers/JASIST2008offPrint.pdf)
+#   (https://www.users.muohio.edu/canf/papers/JASIST2008offPrint.pdf)
 acaba
 altmış
 altı

--- a/src/test/resources/static-schema/collection1/conf/managed-schema
+++ b/src/test/resources/static-schema/collection1/conf/managed-schema
@@ -26,7 +26,7 @@
  It should be kept correct and concise, usable out-of-the-box.
 
  For more information, on how to customize this file, please see
- http://wiki.apache.org/solr/SchemaXml
+ https://wiki.apache.org/solr/SchemaXml
 
  PERFORMANCE NOTE: this schema includes many optional features and should not
  be used for benchmarking.  To improve performance one could
@@ -382,7 +382,7 @@
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
-         http://www.w3.org/TR/xmlschema-2/#dateTime
+         https://www.w3.org/TR/xmlschema-2/#dateTime
          The trailing "Z" designates UTC time and is mandatory.
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
          All other components are mandatory.
@@ -435,7 +435,7 @@
          matching across fields.
 
          For more info on customizing your analyzer chain, please see
-         http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters
+         https://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters
      -->
 
     <!-- One can also specify an existing Analyzer class that has a
@@ -652,7 +652,7 @@
              See the Java Regular Expression documentation for more
              information on pattern and replacement string syntax.
 
-             http://docs.oracle.com/javase/8/docs/api/java/util/regex/package-summary.html
+             https://docs.oracle.com/javase/8/docs/api/java/util/regex/package-summary.html
           -->
         <filter class="solr.PatternReplaceFilterFactory"
                 pattern="([^a-z])" replacement="" replace="all"
@@ -740,7 +740,7 @@
 
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:
-      http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
+      https://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
     -->
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
         geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="kilometers" />
@@ -752,7 +752,7 @@
                geo="true" distanceUnits="kilometers" numberType="_bbox_coord" />
     <fieldType name="_bbox_coord" class="solr.TrieDoubleField" precisionStep="8" docValues="true" useDocValuesAsStored="false" stored="false" />
 
-   <!-- Money/currency field type. See http://wiki.apache.org/solr/MoneyFieldType
+   <!-- Money/currency field type. See https://wiki.apache.org/solr/MoneyFieldType
         Parameters:
           defaultCurrency: Specifies the default currency if none specified. Defaults to "USD"
           precisionStep:   Specifies the precisionStep for the TrieLong field used for the amount
@@ -1049,7 +1049,7 @@
 
            Punctuation characters are discarded by default.  Use discardPunctuation="false" to keep them.
 
-           See http://wiki.apache.org/solr/JapaneseLanguageSupport for more on Japanese language support.
+           See https://wiki.apache.org/solr/JapaneseLanguageSupport for more on Japanese language support.
         -->
         <tokenizer class="solr.JapaneseTokenizerFactory" mode="search"/>
         <!--<tokenizer class="solr.JapaneseTokenizerFactory" mode="search" userDictionary="lang/userdict_ja.txt"/>-->
@@ -1178,7 +1178,7 @@
   <!-- Similarity is the scoring routine for each document vs. a query.
        A custom Similarity or SimilarityFactory may be specified here, but
        the default is fine for most applications.
-       For more info: http://wiki.apache.org/solr/SchemaXml#Similarity
+       For more info: https://wiki.apache.org/solr/SchemaXml#Similarity
     -->
   <!--
      <similarity class="com.example.solr.CustomSimilarityFactory">

--- a/src/test/resources/static-schema/collection1/conf/mapping-FoldToASCII.txt
+++ b/src/test/resources/static-schema/collection1/conf/mapping-FoldToASCII.txt
@@ -35,7 +35,7 @@
 # - Alphabetic Presentation Forms: http://www.unicode.org/charts/PDF/UFB00.pdf
 # - Halfwidth and Fullwidth Forms: http://www.unicode.org/charts/PDF/UFF00.pdf
 #  
-# See: http://en.wikipedia.org/wiki/Latin_characters_in_Unicode
+# See: https://en.wikipedia.org/wiki/Latin_characters_in_Unicode
 #
 # The set of character conversions supported by this map is a superset of
 # those supported by the map represented by mapping-ISOLatin1Accent.txt.
@@ -77,7 +77,7 @@
 # Ą  [LATIN CAPITAL LETTER A WITH OGONEK]
 "\u0104" => "A"
 
-# Ə  http://en.wikipedia.org/wiki/Schwa  [LATIN CAPITAL LETTER SCHWA]
+# Ə  https://en.wikipedia.org/wiki/Schwa  [LATIN CAPITAL LETTER SCHWA]
 "\u018F" => "A"
 
 # Ǎ  [LATIN CAPITAL LETTER A WITH CARON]
@@ -1085,7 +1085,7 @@
 # ｈ  [FULLWIDTH LATIN SMALL LETTER H]
 "\uFF48" => "h"
 
-# Ƕ  http://en.wikipedia.org/wiki/Hwair  [LATIN CAPITAL LETTER HWAIR]
+# Ƕ  https://en.wikipedia.org/wiki/Hwair  [LATIN CAPITAL LETTER HWAIR]
 "\u01F6" => "HV"
 
 # ⒣  [PARENTHESIZED LATIN SMALL LETTER H]
@@ -1595,7 +1595,7 @@
 # Ň  [LATIN CAPITAL LETTER N WITH CARON]
 "\u0147" => "N"
 
-# Ŋ  http://en.wikipedia.org/wiki/Eng_(letter)  [LATIN CAPITAL LETTER ENG]
+# Ŋ  https://en.wikipedia.org/wiki/Eng_(letter)  [LATIN CAPITAL LETTER ENG]
 "\u014A" => "N"
 
 # Ɲ  [LATIN CAPITAL LETTER N WITH LEFT HOOK]
@@ -1646,7 +1646,7 @@
 # ŉ  [LATIN SMALL LETTER N PRECEDED BY APOSTROPHE]
 "\u0149" => "n"
 
-# ŋ  http://en.wikipedia.org/wiki/Eng_(letter)  [LATIN SMALL LETTER ENG]
+# ŋ  https://en.wikipedia.org/wiki/Eng_(letter)  [LATIN SMALL LETTER ENG]
 "\u014B" => "n"
 
 # ƞ  [LATIN SMALL LETTER N WITH LONG RIGHT LEG]
@@ -1985,7 +1985,7 @@
 # Ꝏ  [LATIN CAPITAL LETTER OO]
 "\uA74E" => "OO"
 
-# Ȣ  http://en.wikipedia.org/wiki/OU  [LATIN CAPITAL LETTER OU]
+# Ȣ  https://en.wikipedia.org/wiki/OU  [LATIN CAPITAL LETTER OU]
 "\u0222" => "OU"
 
 # ᴕ  [LATIN LETTER SMALL CAPITAL OU]
@@ -2003,7 +2003,7 @@
 # ꝏ  [LATIN SMALL LETTER OO]
 "\uA74F" => "oo"
 
-# ȣ  http://en.wikipedia.org/wiki/OU  [LATIN SMALL LETTER OU]
+# ȣ  https://en.wikipedia.org/wiki/OU  [LATIN SMALL LETTER OU]
 "\u0223" => "ou"
 
 # Ƥ  [LATIN CAPITAL LETTER P WITH HOOK]
@@ -2090,7 +2090,7 @@
 # Ｑ  [FULLWIDTH LATIN CAPITAL LETTER Q]
 "\uFF31" => "Q"
 
-# ĸ  http://en.wikipedia.org/wiki/Kra_(letter)  [LATIN SMALL LETTER KRA]
+# ĸ  https://en.wikipedia.org/wiki/Kra_(letter)  [LATIN SMALL LETTER KRA]
 "\u0138" => "q"
 
 # ɋ  [LATIN SMALL LETTER Q WITH HOOK TAIL]
@@ -2297,7 +2297,7 @@
 # š  [LATIN SMALL LETTER S WITH CARON]
 "\u0161" => "s"
 
-# ſ  http://en.wikipedia.org/wiki/Long_S  [LATIN SMALL LETTER LONG S]
+# ſ  https://en.wikipedia.org/wiki/Long_S  [LATIN SMALL LETTER LONG S]
 "\u017F" => "s"
 
 # ș  [LATIN SMALL LETTER S WITH COMMA BELOW]
@@ -2777,7 +2777,7 @@
 # Ŵ  [LATIN CAPITAL LETTER W WITH CIRCUMFLEX]
 "\u0174" => "W"
 
-# Ƿ  http://en.wikipedia.org/wiki/Wynn  [LATIN CAPITAL LETTER WYNN]
+# Ƿ  https://en.wikipedia.org/wiki/Wynn  [LATIN CAPITAL LETTER WYNN]
 "\u01F7" => "W"
 
 # ᴡ  [LATIN LETTER SMALL CAPITAL W]
@@ -2810,7 +2810,7 @@
 # ŵ  [LATIN SMALL LETTER W WITH CIRCUMFLEX]
 "\u0175" => "w"
 
-# ƿ  http://en.wikipedia.org/wiki/Wynn  [LATIN LETTER WYNN]
+# ƿ  https://en.wikipedia.org/wiki/Wynn  [LATIN LETTER WYNN]
 "\u01BF" => "w"
 
 # ʍ  [LATIN SMALL LETTER TURNED W]
@@ -2987,7 +2987,7 @@
 # Ƶ  [LATIN CAPITAL LETTER Z WITH STROKE]
 "\u01B5" => "Z"
 
-# Ȝ  http://en.wikipedia.org/wiki/Yogh  [LATIN CAPITAL LETTER YOGH]
+# Ȝ  https://en.wikipedia.org/wiki/Yogh  [LATIN CAPITAL LETTER YOGH]
 "\u021C" => "Z"
 
 # Ȥ  [LATIN CAPITAL LETTER Z WITH HOOK]
@@ -3029,7 +3029,7 @@
 # ƶ  [LATIN SMALL LETTER Z WITH STROKE]
 "\u01B6" => "z"
 
-# ȝ  http://en.wikipedia.org/wiki/Yogh  [LATIN SMALL LETTER YOGH]
+# ȝ  https://en.wikipedia.org/wiki/Yogh  [LATIN SMALL LETTER YOGH]
 "\u021D" => "z"
 
 # ȥ  [LATIN SMALL LETTER Z WITH HOOK]


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://members.unine.ch/jacques.savoy/clef/index.html (200) with 10 occurrences could not be migrated:  
   ([https](https://members.unine.ch/jacques.savoy/clef/index.html) result SSLHandshakeException).
* [ ] http://www.unicode.org/charts/PDF/U0080.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/U0080.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/U0100.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/U0100.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/U0180.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/U0180.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/U0250.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/U0250.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/U1D00.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/U1D00.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/U1D80.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/U1D80.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/U1E00.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/U1E00.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/U2000.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/U2000.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/U2070.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/U2070.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/U2460.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/U2460.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/U2700.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/U2700.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/U2C60.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/U2C60.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/U2E00.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/U2E00.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/UA720.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/UA720.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/UFB00.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/UFB00.pdf) result SSLProtocolException).
* [ ] http://www.unicode.org/charts/PDF/UFF00.pdf (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/charts/PDF/UFF00.pdf) result SSLProtocolException).
* [ ] http://snowball.tartarus.org/license.php (404) with 24 occurrences could not be migrated:  
   ([https](https://snowball.tartarus.org/license.php) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.w3.org/TR/xmlschema-2/ (ReadTimeoutException) with 1 occurrences migrated to:  
  https://www.w3.org/TR/xmlschema-2/ ([https](https://www.w3.org/TR/xmlschema-2/) result SSLException).
* [ ] http://locahost:8983/solr (UnknownHostException) with 1 occurrences migrated to:  
  https://locahost:8983/solr ([https](https://locahost:8983/solr) result UnknownHostException).
* [ ] http://locahost:8983/solr,http://localhost:8984/solr (UnknownHostException) with 1 occurrences migrated to:  
  https://locahost:8983/solr,http://localhost:8984/solr ([https](https://locahost:8983/solr,https://localhost:8984/solr) result UnknownHostException).
* [ ] http://solr.server.url (UnknownHostException) with 1 occurrences migrated to:  
  https://solr.server.url ([https](https://solr.server.url) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.oracle.com/javase/8/docs/api/java/util/regex/package-summary.html with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/8/docs/api/java/util/regex/package-summary.html ([https](https://docs.oracle.com/javase/8/docs/api/java/util/regex/package-summary.html) result 200).
* [ ] http://en.wikipedia.org/wiki/Hwair with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Hwair ([https](https://en.wikipedia.org/wiki/Hwair) result 200).
* [ ] http://en.wikipedia.org/wiki/Latin_characters_in_Unicode with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Latin_characters_in_Unicode ([https](https://en.wikipedia.org/wiki/Latin_characters_in_Unicode) result 200).
* [ ] http://en.wikipedia.org/wiki/Long_S with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Long_S ([https](https://en.wikipedia.org/wiki/Long_S) result 200).
* [ ] http://en.wikipedia.org/wiki/OU with 2 occurrences migrated to:  
  https://en.wikipedia.org/wiki/OU ([https](https://en.wikipedia.org/wiki/OU) result 200).
* [ ] http://en.wikipedia.org/wiki/Schwa with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Schwa ([https](https://en.wikipedia.org/wiki/Schwa) result 200).
* [ ] http://en.wikipedia.org/wiki/Wynn with 2 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Wynn ([https](https://en.wikipedia.org/wiki/Wynn) result 200).
* [ ] http://en.wikipedia.org/wiki/Yogh with 2 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Yogh ([https](https://en.wikipedia.org/wiki/Yogh) result 200).
* [ ] http://github.com/vcl/cue.language with 2 occurrences migrated to:  
  https://github.com/vcl/cue.language ([https](https://github.com/vcl/cue.language) result 200).
* [ ] http://lucene.apache.org/solr/ with 2 occurrences migrated to:  
  https://lucene.apache.org/solr/ ([https](https://lucene.apache.org/solr/) result 200).
* [ ] http://projects.spring.io/spring-data-solr/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-data-solr/ ([https](https://projects.spring.io/spring-data-solr/) result 200).
* [ ] http://spring.io/blog with 1 occurrences migrated to:  
  https://spring.io/blog ([https](https://spring.io/blog) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-data-solr with 2 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-data-solr ([https](https://stackoverflow.com/questions/tagged/spring-data-solr) result 200).
* [ ] http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters with 1 occurrences migrated to:  
  https://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters ([https](https://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters) result 200).
* [ ] http://wiki.apache.org/solr/JapaneseLanguageSupport with 1 occurrences migrated to:  
  https://wiki.apache.org/solr/JapaneseLanguageSupport ([https](https://wiki.apache.org/solr/JapaneseLanguageSupport) result 200).
* [ ] http://wiki.apache.org/solr/SchemaXml with 2 occurrences migrated to:  
  https://wiki.apache.org/solr/SchemaXml ([https](https://wiki.apache.org/solr/SchemaXml) result 200).
* [ ] http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4 with 1 occurrences migrated to:  
  https://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4 ([https](https://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/data/repository/spring-repository.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/data/repository/spring-repository.xsd ([https](https://www.springframework.org/schema/data/repository/spring-repository.xsd) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring-data/data-solr/docs/current/api/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/data-solr/docs/current/api/ ([https](https://docs.spring.io/spring-data/data-solr/docs/current/api/) result 301).
* [ ] http://docs.spring.io/spring-data/data-solr/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-data/data-solr/docs/current/reference/html/ ([https](https://docs.spring.io/spring-data/data-solr/docs/current/reference/html/) result 301).
* [ ] http://en.wikipedia.org/wiki/Eng_ with 2 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Eng_ ([https](https://en.wikipedia.org/wiki/Eng_) result 301).
* [ ] http://en.wikipedia.org/wiki/Kra_ with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Kra_ ([https](https://en.wikipedia.org/wiki/Kra_) result 301).
* [ ] http://help.github.com/forking/ with 1 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://projects.spring.io/spring-data with 2 occurrences migrated to:  
  https://projects.spring.io/spring-data ([https](https://projects.spring.io/spring-data) result 301).
* [ ] http://www.opensource.org/licenses/bsd-license.html with 34 occurrences migrated to:  
  https://www.opensource.org/licenses/bsd-license.html ([https](https://www.opensource.org/licenses/bsd-license.html) result 301).
* [ ] http://www.springframework.org/schema/data/solr/spring-solr.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/data/solr/spring-solr.xsd ([https](https://www.springframework.org/schema/data/solr/spring-solr.xsd) result 301).
* [ ] http://www.users.muohio.edu/canf/papers/JASIST2008offPrint.pdf with 2 occurrences migrated to:  
  https://www.users.muohio.edu/canf/papers/JASIST2008offPrint.pdf ([https](https://www.users.muohio.edu/canf/papers/JASIST2008offPrint.pdf) result 301).
* [ ] http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* [ ] http://wiki.apache.org/solr/MoneyFieldType with 1 occurrences migrated to:  
  https://wiki.apache.org/solr/MoneyFieldType ([https](https://wiki.apache.org/solr/MoneyFieldType) result 302).
* [ ] http://www.springsource.org/download with 1 occurrences migrated to:  
  https://www.springsource.org/download ([https](https://www.springsource.org/download) result 302).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1/solr with 1 occurrences
* http://127.0.0.1/solr/ with 1 occurrences
* http://localhost:8983 with 1 occurrences
* http://localhost:8983/solr with 2 occurrences
* http://www.springframework.org/schema/beans with 18 occurrences
* http://www.springframework.org/schema/data/repository with 8 occurrences
* http://www.springframework.org/schema/data/solr with 18 occurrences
* http://www.springframework.org/schema/tool with 8 occurrences
* http://www.w3.org/2001/XMLSchema with 4 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 5 occurrences