### PR TITLE
DATASOLR-333 - Make solr-cloud support basic Auth.

### DIFF
--- a/src/main/java/org/springframework/data/solr/server/support/SolrClientFactoryBase.java
+++ b/src/main/java/org/springframework/data/solr/server/support/SolrClientFactoryBase.java
@@ -16,6 +16,7 @@
 package org.springframework.data.solr.server.support;
 
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.data.solr.server.SolrClientFactory;
@@ -42,6 +43,10 @@ abstract class SolrClientFactoryBase implements SolrClientFactory, DisposableBea
 
 	protected final boolean isHttpSolrClient(SolrClient solrClient) {
 		return (solrClient instanceof HttpSolrClient);
+	}
+
+	protected final boolean isCloudSolrClient(SolrClient solrClient) {
+		return (solrClient instanceof CloudSolrClient);
 	}
 
 	@Override


### PR DESCRIPTION
This PR provides the support for basic auth in solr-cloud connection. This does not add
a new class and uses the httpSolrClientFactory wich allready works with solr-cloud and
also add the support for basic auth.


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATASOLR).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
