### PR TITLE
DATASOLR-564 - Add support for JSON facets.

### DIFF
--- a/src/main/java/org/springframework/data/solr/core/SolrTemplate.java
+++ b/src/main/java/org/springframework/data/solr/core/SolrTemplate.java
@@ -91,6 +91,7 @@ import org.springframework.util.CollectionUtils;
  * @author Petar Tahchiev
  * @author Mark Paluch
  * @author Juan Manuel de Blas
+ * @author Joe Linn
  */
 public class SolrTemplate implements SolrOperations, InitializingBean, ApplicationContextAware {
 
@@ -461,6 +462,8 @@ public class SolrTemplate implements SolrOperations, InitializingBean, Applicati
 					ResultHelper.convertFacetQueryResponseToFacetPivotMap((FacetQuery) query, response));
 			page.addAllRangeFacetFieldResultPages(
 					ResultHelper.convertFacetQueryResponseToRangeFacetPageMap((FacetQuery) query, response));
+			page.addAllJsonFacetResults(
+					ResultHelper.convertJsonFacetQueryResponseToFacetResultMap((FacetQuery) query, response));
 		}
 
 		if (query.getSpellcheckOptions() != null) {

--- a/src/main/java/org/springframework/data/solr/core/query/AbstractJsonFacet.java
+++ b/src/main/java/org/springframework/data/solr/core/query/AbstractJsonFacet.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query;
+
+/**
+ * @author Joe Linn
+ */
+public abstract class AbstractJsonFacet implements JsonFacet {
+	private String name;
+
+	public AbstractJsonFacet() {}
+
+	public AbstractJsonFacet(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * @return the type of JSON facet represented by this class. This string will be passed to Solr at request time.
+	 */
+	public abstract String getType();
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Sets the name of this JSON facet.
+	 * 
+	 * @param name facet name. Should be unique within the current request and nesting level.
+	 * @return
+	 */
+	public <T extends AbstractJsonFacet> T setName(String name) {
+		this.name = name;
+		return (T) this;
+	}
+}

--- a/src/main/java/org/springframework/data/solr/core/query/FacetOptions.java
+++ b/src/main/java/org/springframework/data/solr/core/query/FacetOptions.java
@@ -20,7 +20,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.solr.common.params.FacetParams;
 import org.apache.solr.common.params.FacetParams.FacetRangeInclude;
@@ -35,6 +37,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Christoph Strobl
  * @author Francisco Spaeth
+ * @author Joe Linn
  */
 public class FacetOptions {
 
@@ -50,6 +53,7 @@ public class FacetOptions {
 	private List<PivotField> facetOnPivotFields = new ArrayList<>(0);
 	private List<FieldWithRangeParameters<?, ?, ?>> facetRangeOnFields = new ArrayList<>(1);
 	private List<SolrDataQuery> facetQueries = new ArrayList<>(0);
+	private Map<String, JsonFacet> jsonFacets = new HashMap<>();
 
 	private int facetMinCount = DEFAULT_FACET_MIN_COUNT;
 	private int facetLimit = DEFAULT_FACET_LIMIT;
@@ -353,10 +357,10 @@ public class FacetOptions {
 	}
 
 	/**
-	 * @return true if any {@code facet.field} or {@code facet.query} set
+	 * @return true if any {@code facet.field} or {@code facet.query} or {@code json.facet} set
 	 */
 	public boolean hasFacets() {
-		return hasFields() || hasFacetQueries() || hasPivotFields() || hasFacetRages();
+		return hasFields() || hasFacetQueries() || hasPivotFields() || hasFacetRages() || hasJsonFacets();
 	}
 
 	/**
@@ -378,6 +382,31 @@ public class FacetOptions {
 
 		}
 		return result;
+	}
+
+	/**
+	 * @return any configured JSON facets
+	 */
+	public Map<String, JsonFacet> getJsonFacets() {
+		return jsonFacets;
+	}
+
+	/**
+	 * @return true if any JSON facets have been configured
+	 */
+	public boolean hasJsonFacets() {
+		return !jsonFacets.isEmpty();
+	}
+
+	/**
+	 * Adds a JSON facet ({@code json.facet})
+	 * 
+	 * @param facet the facet to be added
+	 * @return
+	 */
+	public FacetOptions addJsonFacet(JsonFacet facet) {
+		jsonFacets.put(facet.getName(), facet);
+		return this;
 	}
 
 	public static class FacetParameter extends QueryParameterImpl {

--- a/src/main/java/org/springframework/data/solr/core/query/JsonFacet.java
+++ b/src/main/java/org/springframework/data/solr/core/query/JsonFacet.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query;
+
+/**
+ * @author Joe Linn
+ */
+public interface JsonFacet {
+	/**
+	 * @return the name assigned to this facet
+	 */
+	String getName();
+}

--- a/src/main/java/org/springframework/data/solr/core/query/JsonFieldFacet.java
+++ b/src/main/java/org/springframework/data/solr/core/query/JsonFieldFacet.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query;
+
+/**
+ * Represents a JSON facet that operates on a single field
+ * 
+ * @author Joe Linn
+ */
+public abstract class JsonFieldFacet extends NestedJsonFacet {
+	private String field;
+
+	public JsonFieldFacet() {}
+
+	public JsonFieldFacet(String name, String field) {
+		super(name);
+		this.field = field;
+	}
+
+	/**
+	 * @return the name of the field on which this JSON facet will operate
+	 */
+	public String getField() {
+		return field;
+	}
+
+	public <T extends JsonFieldFacet> T setField(String field) {
+		this.field = field;
+		return (T) this;
+	}
+}

--- a/src/main/java/org/springframework/data/solr/core/query/JsonQueryFacet.java
+++ b/src/main/java/org/springframework/data/solr/core/query/JsonQueryFacet.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query;
+
+/**
+ * Represents a JSON <a href="https://lucene.apache.org/solr/guide/8_5/json-facet-api.html#query-facet">query facet</a>.
+ * 
+ * @author Joe Linn
+ */
+public class JsonQueryFacet extends NestedJsonFacet {
+	private Criteria query;
+
+	public JsonQueryFacet() {}
+
+	public JsonQueryFacet(String name, Criteria query) {
+		super(name);
+		this.query = query;
+	}
+
+	public Criteria getQuery() {
+		return query;
+	}
+
+	public JsonQueryFacet setQuery(Criteria query) {
+		this.query = query;
+		return this;
+	}
+
+	@Override
+	public String getType() {
+		return "query";
+	}
+}

--- a/src/main/java/org/springframework/data/solr/core/query/JsonRangeFacet.java
+++ b/src/main/java/org/springframework/data/solr/core/query/JsonRangeFacet.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a JSON <a href="https://lucene.apache.org/solr/guide/8_5/json-facet-api.html#range-facet">range facet</a>.
+ * 
+ * @author Joe Linn
+ */
+public class JsonRangeFacet extends JsonFieldFacet {
+	private Number start;
+	private Number end;
+	private Number gap;
+	@JsonProperty("hardend") private Boolean hardEnd;
+	private Other other;
+	private Include include = Include.LOWER;
+	private List<Range> ranges = new LinkedList<>();
+
+	@Override
+	public String getType() {
+		return "range";
+	}
+
+	public Number getStart() {
+		return start;
+	}
+
+	public JsonRangeFacet setStart(Number start) {
+		this.start = start;
+		return this;
+	}
+
+	public Number getEnd() {
+		return end;
+	}
+
+	public JsonRangeFacet setEnd(Number end) {
+		this.end = end;
+		return this;
+	}
+
+	public Number getGap() {
+		return gap;
+	}
+
+	public JsonRangeFacet setGap(Number gap) {
+		this.gap = gap;
+		return this;
+	}
+
+	public Boolean isHardEnd() {
+		return hardEnd;
+	}
+
+	public JsonRangeFacet setHardEnd(Boolean hardEnd) {
+		this.hardEnd = hardEnd;
+		return this;
+	}
+
+	public Other getOther() {
+		return other;
+	}
+
+	public JsonRangeFacet setOther(Other other) {
+		this.other = other;
+		return this;
+	}
+
+	public Include getInclude() {
+		return include;
+	}
+
+	public JsonRangeFacet setInclude(Include include) {
+		this.include = include;
+		return this;
+	}
+
+	public List<Range> getRanges() {
+		return ranges;
+	}
+
+	public JsonRangeFacet setRanges(List<Range> ranges) {
+		this.ranges = ranges;
+		return this;
+	}
+
+	public JsonRangeFacet addRange(Range range) {
+		ranges.add(range);
+		return this;
+	}
+
+	public static enum Other {
+		BEFORE, AFTER, BETWEEN, NONE, ALL;
+	}
+
+	public static enum Include {
+		LOWER, UPPER, EDGE, OUTER, ALL;
+	}
+
+	public static class Range {
+		private Number from;
+		private Number to;
+		@JsonProperty("inclusive_from") private boolean inclusiveFrom = true;
+		@JsonProperty("inclusive_to") private boolean inclusiveTo = false;
+
+		public Number getFrom() {
+			return from;
+		}
+
+		public Range setFrom(Number from) {
+			this.from = from;
+			return this;
+		}
+
+		public Number getTo() {
+			return to;
+		}
+
+		public Range setTo(Number to) {
+			this.to = to;
+			return this;
+		}
+
+		public boolean isInclusiveFrom() {
+			return inclusiveFrom;
+		}
+
+		public Range setInclusiveFrom(boolean inclusiveFrom) {
+			this.inclusiveFrom = inclusiveFrom;
+			return this;
+		}
+
+		public boolean isInclusiveTo() {
+			return inclusiveTo;
+		}
+
+		public Range setInclusiveTo(boolean inclusiveTo) {
+			this.inclusiveTo = inclusiveTo;
+			return this;
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/solr/core/query/JsonStatFacet.java
+++ b/src/main/java/org/springframework/data/solr/core/query/JsonStatFacet.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a JSON <a href="https://lucene.apache.org/solr/guide/8_5/json-facet-api.html#stat-facet-functions">stats
+ * facet</a>.
+ * 
+ * @author Joe Linn
+ */
+public class JsonStatFacet extends AbstractJsonFacet {
+	@JsonProperty("func") private StatFacetFunction function;
+	private Map<String, Object> params = new HashMap<>();
+
+	public JsonStatFacet() {}
+
+	public JsonStatFacet(String name, StatFacetFunction function) {
+		super(name);
+		this.function = function;
+	}
+
+	@Override
+	public String getType() {
+		return "func";
+	}
+
+	public StatFacetFunction getFunction() {
+		return function;
+	}
+
+	public JsonStatFacet setFunction(StatFacetFunction function) {
+		this.function = function;
+		return this;
+	}
+
+	@JsonAnyGetter
+	public Map<String, Object> getParams() {
+		return params;
+	}
+
+	public JsonStatFacet setParams(Map<String, Object> params) {
+		this.params = params;
+		return this;
+	}
+
+	public JsonStatFacet addParam(String name, Object value) {
+		this.params.put(name, value);
+		return this;
+	}
+}

--- a/src/main/java/org/springframework/data/solr/core/query/JsonTermsFacet.java
+++ b/src/main/java/org/springframework/data/solr/core/query/JsonTermsFacet.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query;
+
+/**
+ * Represents a JSON <a href="https://lucene.apache.org/solr/guide/8_5/json-facet-api.html#terms-facet">terms facet</a>.
+ * 
+ * @author Joe Linn
+ */
+public class JsonTermsFacet extends JsonFieldFacet {
+	private int offset;
+	private int limit = 10;
+	private TermsOptions.Sort sort = TermsOptions.DEFAULT_SORT;
+	private int overRequest = -1;
+	private boolean refine;
+	private int overRefine = -1;
+	private int minCount = 1;
+	private boolean missing;
+	private boolean numBuckets;
+	private boolean allBuckets;
+	private String prefix;
+	private Method method = Method.SMART;
+
+	public JsonTermsFacet() {}
+
+	public JsonTermsFacet(String name, String field) {
+		super(name, field);
+	}
+
+	public int getOffset() {
+		return offset;
+	}
+
+	public JsonTermsFacet setOffset(int offset) {
+		this.offset = offset;
+		return this;
+	}
+
+	public int getLimit() {
+		return limit;
+	}
+
+	public JsonTermsFacet setLimit(int limit) {
+		this.limit = limit;
+		return this;
+	}
+
+	public TermsOptions.Sort getSort() {
+		return sort;
+	}
+
+	public JsonTermsFacet setSort(TermsOptions.Sort sort) {
+		this.sort = sort;
+		return this;
+	}
+
+	public int getOverRequest() {
+		return overRequest;
+	}
+
+	public JsonTermsFacet setOverRequest(int overRequest) {
+		this.overRequest = overRequest;
+		return this;
+	}
+
+	public boolean isRefine() {
+		return refine;
+	}
+
+	public JsonTermsFacet setRefine(boolean refine) {
+		this.refine = refine;
+		return this;
+	}
+
+	public int getOverRefine() {
+		return overRefine;
+	}
+
+	public JsonTermsFacet setOverRefine(int overRefine) {
+		this.overRefine = overRefine;
+		return this;
+	}
+
+	public int getMinCount() {
+		return minCount;
+	}
+
+	public JsonTermsFacet setMinCount(int minCount) {
+		this.minCount = minCount;
+		return this;
+	}
+
+	public boolean isMissing() {
+		return missing;
+	}
+
+	public JsonTermsFacet setMissing(boolean missing) {
+		this.missing = missing;
+		return this;
+	}
+
+	public boolean isNumBuckets() {
+		return numBuckets;
+	}
+
+	public JsonTermsFacet setNumBuckets(boolean numBuckets) {
+		this.numBuckets = numBuckets;
+		return this;
+	}
+
+	public boolean isAllBuckets() {
+		return allBuckets;
+	}
+
+	public JsonTermsFacet setAllBuckets(boolean allBuckets) {
+		this.allBuckets = allBuckets;
+		return this;
+	}
+
+	public String getPrefix() {
+		return prefix;
+	}
+
+	public JsonTermsFacet setPrefix(String prefix) {
+		this.prefix = prefix;
+		return this;
+	}
+
+	public Method getMethod() {
+		return method;
+	}
+
+	public JsonTermsFacet setMethod(Method method) {
+		this.method = method;
+		return this;
+	}
+
+	@Override
+	public String getType() {
+		return "terms";
+	}
+
+	public enum Method {
+		DV, UIF, DVHASH, ENUM, STREAM, SMART;
+	}
+}

--- a/src/main/java/org/springframework/data/solr/core/query/NestedJsonFacet.java
+++ b/src/main/java/org/springframework/data/solr/core/query/NestedJsonFacet.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a JSON facet which can contain nested facets.
+ * 
+ * @author Joe Linn
+ */
+public abstract class NestedJsonFacet extends AbstractJsonFacet {
+	@JsonProperty("facet") private Map<String, JsonFacet> facets = new HashMap<>();
+
+	public NestedJsonFacet() {}
+
+	public NestedJsonFacet(String name) {
+		super(name);
+	}
+
+	public Map<String, JsonFacet> getFacets() {
+		return facets;
+	}
+
+	public void setFacets(Map<String, JsonFacet> facets) {
+		this.facets = facets;
+	}
+
+	/**
+	 * Adds a {@link JsonFacet} as a nested facet of this facet.
+	 * 
+	 * @param facet the facet to be added
+	 * @return
+	 */
+	public <T extends NestedJsonFacet> T addFacet(JsonFacet facet) {
+		this.facets.put(facet.getName(), facet);
+		return (T) this;
+	}
+}

--- a/src/main/java/org/springframework/data/solr/core/query/StatFacetFunction.java
+++ b/src/main/java/org/springframework/data/solr/core/query/StatFacetFunction.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query;
+
+import java.util.Arrays;
+
+import com.google.common.base.CaseFormat;
+
+/**
+ * @author Joe Linn
+ */
+public class StatFacetFunction extends AbstractFunction {
+	private final Func func;
+
+	public StatFacetFunction(Func func, Object... arguments) {
+		super(Arrays.asList(arguments));
+		this.func = func;
+	}
+
+	@Override
+	public String getOperation() {
+		return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, func.name());
+	}
+
+	@Override
+	public String toSolrFunction(Context context) {
+		StringBuilder str = new StringBuilder(getOperation()).append("(");
+		String comma = "";
+		for (Object parameter : getArguments()) {
+			str.append(comma);
+			if (parameter instanceof StatFacetFunction) {
+				str.append(((StatFacetFunction) parameter).toSolrFunction(context));
+			} else {
+				str.append(context.convert(parameter));
+			}
+			comma = ",";
+		}
+		str.append(")");
+		return str.toString();
+	}
+
+	public static StatFacetFunction sum(String field) {
+		return new StatFacetFunction(Func.SUM, field);
+	}
+
+	public static StatFacetFunction sum(StatFacetFunction function) {
+		return new StatFacetFunction(Func.SUM, function);
+	}
+
+	public static StatFacetFunction avg(String field) {
+		return new StatFacetFunction(Func.AVG, field);
+	}
+
+	public static StatFacetFunction avg(StatFacetFunction function) {
+		return new StatFacetFunction(Func.AVG, function);
+	}
+
+	public static StatFacetFunction min(String field) {
+		return new StatFacetFunction(Func.MIN, field);
+	}
+
+	public static StatFacetFunction min(StatFacetFunction function) {
+		return new StatFacetFunction(Func.MIN, function);
+	}
+
+	public static StatFacetFunction max(String field) {
+		return new StatFacetFunction(Func.MAX, field);
+	}
+
+	public static StatFacetFunction max(StatFacetFunction function) {
+		return new StatFacetFunction(Func.MAX, function);
+	}
+
+	public static StatFacetFunction missing(String field) {
+		return new StatFacetFunction(Func.MISSING, field);
+	}
+
+	public static StatFacetFunction missing(StatFacetFunction function) {
+		return new StatFacetFunction(Func.MISSING, function);
+	}
+
+	public static StatFacetFunction countvals(String field) {
+		return new StatFacetFunction(Func.COUNTVALS, field);
+	}
+
+	public static StatFacetFunction countvals(StatFacetFunction function) {
+		return new StatFacetFunction(Func.COUNTVALS, function);
+	}
+
+	public static StatFacetFunction unique(String field) {
+		return new StatFacetFunction(Func.UNIQUE, field);
+	}
+
+	public static StatFacetFunction uniqueBlock(String field) {
+		return new StatFacetFunction(Func.UNIQUE_BLOCK, field);
+	}
+
+	public static StatFacetFunction uniqueBlock(Criteria criteria) {
+		return new StatFacetFunction(Func.UNIQUE_BLOCK, criteria);
+	}
+
+	public static StatFacetFunction hll(String field) {
+		return new StatFacetFunction(Func.HLL, field);
+	}
+
+	// bug in solrj causes results of percentile ƒacet to not be parsed properly:
+	// https://issues.apache.org/jira/browse/SOLR-14006
+	/*public static StatFacetFunction percentile(String field, float... quantiles) {
+	    return percentile((Object) field, quantiles);
+	}
+	
+	public static StatFacetFunction percentile(StatFacetFunction function, float... quantiles) {
+	    return percentile((Object) function, quantiles);
+	}*/
+
+	private static StatFacetFunction percentile(Object fieldOrFunction, float... quantiles) {
+		Object[] params = new Object[quantiles.length + 1];
+		params[0] = fieldOrFunction;
+		for (int i = 0; i < quantiles.length; i++) {
+			params[i + 1] = quantiles[i];
+		}
+		return new StatFacetFunction(Func.PERCENTILE, params);
+	}
+
+	public static StatFacetFunction sumsq(String field) {
+		return new StatFacetFunction(Func.SUMSQ, field);
+	}
+
+	public static StatFacetFunction sumsq(StatFacetFunction function) {
+		return new StatFacetFunction(Func.SUMSQ, function);
+	}
+
+	public static StatFacetFunction variance(String field) {
+		return new StatFacetFunction(Func.VARIANCE, field);
+	}
+
+	public static StatFacetFunction variance(StatFacetFunction function) {
+		return new StatFacetFunction(Func.VARIANCE, function);
+	}
+
+	public static StatFacetFunction stddev(String field) {
+		return new StatFacetFunction(Func.STDDEV, field);
+	}
+
+	public static StatFacetFunction stddev(StatFacetFunction function) {
+		return new StatFacetFunction(Func.STDDEV, function);
+	}
+
+	public static StatFacetFunction relatedness(String foreground, String background) {
+		return new StatFacetFunction(Func.RELATEDNESS, foreground, background);
+	}
+
+	public enum Func {
+		SUM, AVG, MIN, MAX, MISSING, COUNTVALS, UNIQUE, UNIQUE_BLOCK, HLL, PERCENTILE, SUMSQ, VARIANCE, STDDEV, RELATEDNESS
+	}
+}

--- a/src/main/java/org/springframework/data/solr/core/query/result/AbstractJsonFacetResult.java
+++ b/src/main/java/org/springframework/data/solr/core/query/result/AbstractJsonFacetResult.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query.result;
+
+/**
+ * @author Joe Linn
+ */
+public abstract class AbstractJsonFacetResult implements JsonFacetResult {
+	private long count;
+
+	protected AbstractJsonFacetResult(long count) {
+		this.count = count;
+	}
+
+	@Override
+	public long getCount() {
+		return count;
+	}
+}

--- a/src/main/java/org/springframework/data/solr/core/query/result/BucketFacetEntry.java
+++ b/src/main/java/org/springframework/data/solr/core/query/result/BucketFacetEntry.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query.result;
+
+import java.util.Map;
+
+/**
+ * Represents a single bucket in a multi-bucketed (terms, range) JSON facet result.
+ * 
+ * @author Joe Linn
+ */
+public class BucketFacetEntry extends ValueCountEntry implements NestableFacetEntry {
+	private Map<String, JsonFacetResult> facets;
+	private Object value;
+
+	public BucketFacetEntry(Object value, long valueCount) {
+		super(value.toString(), valueCount);
+		this.value = value;
+	}
+
+	public BucketFacetEntry(Object value, long valueCount, Map<String, JsonFacetResult> facets) {
+		this(value, valueCount);
+		this.facets = facets;
+	}
+
+	@Override
+	public Map<String, JsonFacetResult> getFacets() {
+		return facets;
+	}
+
+	@Override
+	public Object getKey() {
+		return value;
+	}
+
+	/**
+	 * Attempts to return the {@link #value} of this bucket as a number if possible.
+	 * 
+	 * @return this bucket's value in number form
+	 */
+	public Number getValueAsNumber() {
+		if (value instanceof Number) {
+			return (Number) value;
+		} else {
+			return Double.parseDouble((String) value);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/solr/core/query/result/BucketFacetResult.java
+++ b/src/main/java/org/springframework/data/solr/core/query/result/BucketFacetResult.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query.result;
+
+import java.util.List;
+
+/**
+ * @author Joe Linn
+ */
+public interface BucketFacetResult extends JsonFacetResult {
+	/**
+	 * @return a List of all buckets in this facet result
+	 */
+	List<BucketFacetEntry> getBuckets();
+}

--- a/src/main/java/org/springframework/data/solr/core/query/result/FacetQueryResult.java
+++ b/src/main/java/org/springframework/data/solr/core/query/result/FacetQueryResult.java
@@ -17,6 +17,7 @@ package org.springframework.data.solr.core.query.result;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.solr.core.query.Field;
@@ -27,6 +28,7 @@ import org.springframework.data.solr.core.query.PivotField;
  *
  * @param <T>
  * @author David Webb
+ * @author Joe Linn
  * @since 2.1.0
  */
 public interface FacetQueryResult<T> {
@@ -83,6 +85,11 @@ public interface FacetQueryResult<T> {
 	 * @return Collection holding faceting result pages
 	 */
 	Collection<Page<FacetFieldEntry>> getFacetResultPages();
+
+	/**
+	 * @return Map of JSON facet names to their results
+	 */
+	Map<String, JsonFacetResult> getJsonFacetResults();
 
 	/**
 	 * @return empty collection if not set

--- a/src/main/java/org/springframework/data/solr/core/query/result/JsonFacetResult.java
+++ b/src/main/java/org/springframework/data/solr/core/query/result/JsonFacetResult.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query.result;
+
+/**
+ * @author Joe Linn
+ */
+public interface JsonFacetResult {
+	/**
+	 * @return the total number of documents which match this facet result
+	 */
+	long getCount();
+}

--- a/src/main/java/org/springframework/data/solr/core/query/result/MultiBucketJsonFacetResult.java
+++ b/src/main/java/org/springframework/data/solr/core/query/result/MultiBucketJsonFacetResult.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query.result;
+
+import java.util.List;
+
+/**
+ * @author Joe Linn
+ */
+public class MultiBucketJsonFacetResult extends AbstractJsonFacetResult implements BucketFacetResult {
+	private List<BucketFacetEntry> buckets;
+
+	public MultiBucketJsonFacetResult(long count, List<BucketFacetEntry> buckets) {
+		super(count);
+		this.buckets = buckets;
+	}
+
+	@Override
+	public List<BucketFacetEntry> getBuckets() {
+		return buckets;
+	}
+}

--- a/src/main/java/org/springframework/data/solr/core/query/result/NestableFacetEntry.java
+++ b/src/main/java/org/springframework/data/solr/core/query/result/NestableFacetEntry.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query.result;
+
+import java.util.Map;
+
+/**
+ * @author Joe Linn
+ */
+public interface NestableFacetEntry extends FacetEntry {
+	/**
+	 * @return a Map of nested facet names to their results
+	 */
+	Map<String, JsonFacetResult> getFacets();
+}

--- a/src/main/java/org/springframework/data/solr/core/query/result/SingleBucketJsonFacetResult.java
+++ b/src/main/java/org/springframework/data/solr/core/query/result/SingleBucketJsonFacetResult.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query.result;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Joe Linn
+ */
+public class SingleBucketJsonFacetResult extends AbstractJsonFacetResult {
+	private Map<String, JsonFacetResult> facets;
+
+	public SingleBucketJsonFacetResult(long count) {
+		super(count);
+		facets = new HashMap<>();
+	}
+
+	public SingleBucketJsonFacetResult(long count, Map<String, JsonFacetResult> facets) {
+		super(count);
+		this.facets = facets;
+	}
+
+	public Map<String, JsonFacetResult> getFacets() {
+		return facets;
+	}
+}

--- a/src/main/java/org/springframework/data/solr/core/query/result/SingleStatJsonFacetResult.java
+++ b/src/main/java/org/springframework/data/solr/core/query/result/SingleStatJsonFacetResult.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012 - 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.solr.core.query.result;
+
+/**
+ * @author Joe Linn
+ */
+public class SingleStatJsonFacetResult extends AbstractJsonFacetResult {
+	private Number value;
+
+	public SingleStatJsonFacetResult(long count, Number value) {
+		super(count);
+		this.value = value;
+	}
+
+	public Number getValue() {
+		return value;
+	}
+
+	@Override
+	public String toString() {
+		return "SingleStatJsonFacetResult{" + "value=" + value + '}';
+	}
+}

--- a/src/main/java/org/springframework/data/solr/core/query/result/SolrResultPage.java
+++ b/src/main/java/org/springframework/data/solr/core/query/result/SolrResultPage.java
@@ -43,6 +43,7 @@ import org.springframework.util.ObjectUtils;
  * @author Francisco Spaeth
  * @author David Webb
  * @author Petar Tahchiev
+ * @author Joe Linn
  */
 public class SolrResultPage<T> extends PageImpl<T> implements FacetPage<T>, HighlightPage<T>, FacetAndHighlightPage<T>,
 		ScoredPage<T>, GroupPage<T>, StatsPage<T>, SpellcheckedPage<T> {
@@ -52,6 +53,7 @@ public class SolrResultPage<T> extends PageImpl<T> implements FacetPage<T>, High
 	private Map<PageKey, Page<FacetFieldEntry>> facetResultPages = new LinkedHashMap<>(1);
 	private Map<PageKey, List<FacetPivotFieldEntry>> facetPivotResultPages = new LinkedHashMap<>();
 	private Map<PageKey, Page<FacetFieldEntry>> facetRangeResultPages = new LinkedHashMap<>(1);
+	private Map<String, JsonFacetResult> jsonFacetResults = new LinkedHashMap<>();
 	private @Nullable Page<FacetQueryEntry> facetQueryResult;
 	private List<HighlightEntry<T>> highlighted = Collections.emptyList();
 	private @Nullable Float maxScore;
@@ -148,6 +150,15 @@ public class SolrResultPage<T> extends PageImpl<T> implements FacetPage<T>, High
 		for (Map.Entry<PivotField, List<FacetPivotFieldEntry>> entry : resultMap.entrySet()) {
 			addFacetPivotResultPage(entry.getValue(), entry.getKey());
 		}
+	}
+
+	public void addAllJsonFacetResults(Map<String, JsonFacetResult> resultMap) {
+		this.jsonFacetResults.putAll(resultMap);
+	}
+
+	@Override
+	public Map<String, JsonFacetResult> getJsonFacetResults() {
+		return jsonFacetResults;
 	}
 
 	@Override


### PR DESCRIPTION
This change adds basic JSON faceting support.  As noted in the commentary in `NestedJsonFacet`, there is a bug in Solr / SolrJ which prevents us from easily parsing the results of percentile facets.  There is a [proposed patch](https://issues.apache.org/jira/browse/SOLR-14006) which should fix the issue, but it has not been merged yet.  We could work around the issue to parse those results now, but it'd be pretty nasty.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATASOLR).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
